### PR TITLE
Allow users to bring their own SQL store Entity types

### DIFF
--- a/eventful-postgresql/tests/Eventful/Store/PostgresqlSpec.hs
+++ b/eventful-postgresql/tests/Eventful/Store/PostgresqlSpec.hs
@@ -41,4 +41,4 @@ spec :: Spec
 spec = do
   describe "Postgresql event store" $ do
     eventStoreSpec makeStore (flip runSqlPool)
-    sequencedEventStoreSpec sqlGetGloballyOrderedEvents makeStore (flip runSqlPool)
+    sequencedEventStoreSpec (sqlGetGloballyOrderedEvents defaultSqlEventStoreConfig) makeStore (flip runSqlPool)

--- a/eventful-postgresql/tests/Eventful/Store/PostgresqlSpec.hs
+++ b/eventful-postgresql/tests/Eventful/Store/PostgresqlSpec.hs
@@ -9,16 +9,17 @@ import Test.Hspec
 import Eventful.Store.Postgresql
 import Eventful.TestHelpers
 
-makeStore :: (MonadIO m) => m (PostgresqlEventStore m, ConnectionPool)
+makeStore :: (MonadIO m) => m (PostgresqlEventStore SqlEvent JSONString m, ConnectionPool)
 makeStore = do
   -- TODO: Obviously this is hard-coded, make this use environment variables or
   -- something in the future.
-  let connString = "host=192.168.168.168 port=5432 user=postgres dbname=eventful_test password=password"
-
+  let
+    connString = "host=192.168.168.168 port=5432 user=postgres dbname=eventful_test password=password"
+    store = postgresqlEventStore defaultSqlEventStoreConfig
   pool <- liftIO $ runNoLoggingT (createPostgresqlPool connString 1)
   initializePostgresqlEventStore pool
   liftIO $ runSqlPool truncateTables pool
-  return (postgresqlEventStore, pool)
+  return (store, pool)
 
 getTables :: MonadIO m => SqlPersistT m [Text]
 getTables = do
@@ -41,4 +42,4 @@ spec :: Spec
 spec = do
   describe "Postgresql event store" $ do
     eventStoreSpec makeStore (flip runSqlPool)
-    sequencedEventStoreSpec (sqlGetGloballyOrderedEvents defaultSqlEventStoreConfig) makeStore (flip runSqlPool)
+    sequencedEventStoreSpec sqlGetGloballyOrderedEvents makeStore (flip runSqlPool)

--- a/eventful-sql-common/src/Eventful/Store/Sql.hs
+++ b/eventful-sql-common/src/Eventful/Store/Sql.hs
@@ -1,83 +1,8 @@
-{-# LANGUAGE QuasiQuotes #-}
-
 module Eventful.Store.Sql
   ( module X
-  , SqlEvent (..)
-  , SqlEventId
-  , migrateSqlEvent
-  , sqlGetGloballyOrderedEvents
-  , sqlGetProjectionIds
-  , sqlGetAggregateEvents
-  , sqlMaxEventVersion
-  , sqlStoreEvents
   ) where
 
+import Eventful.Store.Sql.DefaultEntity as X
 import Eventful.Store.Sql.JSONString as X
+import Eventful.Store.Sql.Operations as X
 import Eventful.Store.Sql.Orphans as X ()
-
-import Control.Monad.Reader
-import Data.Maybe (listToMaybe, maybe)
-import Data.Text (Text)
-import Database.Persist
-import Database.Persist.Sql
-import Database.Persist.TH
-
-import Eventful.Store.Class
-import Eventful.UUID
-
-share [mkPersist sqlSettings, mkMigrate "migrateSqlEvent"] [persistLowerCase|
-SqlEvent sql=events
-    Id SequenceNumber sql=sequence_number
-    projectionId UUID
-    version EventVersion
-    data JSONString
-    UniqueAggregateVersion projectionId version
-    deriving Show
-|]
-
-sqlGetGloballyOrderedEvents
-  :: (MonadIO m)
-  => GetGloballyOrderedEvents () (StoredEvent JSONString) (SqlPersistT m)
-sqlGetGloballyOrderedEvents =
-  GetGloballyOrderedEvents $ const sqlGetAllEventsFromSequence
-
-sqlEventToGloballyOrdered :: Entity SqlEvent -> GloballyOrderedEvent (StoredEvent JSONString)
-sqlEventToGloballyOrdered (Entity (SqlEventKey seqNum) event) =
-  GloballyOrderedEvent seqNum $ sqlEventToStored event
-
-sqlEventToStored :: SqlEvent -> StoredEvent JSONString
-sqlEventToStored (SqlEvent uuid version data') =
-  StoredEvent uuid version data'
-
-sqlGetProjectionIds :: (MonadIO m) => ReaderT SqlBackend m [UUID]
-sqlGetProjectionIds =
-  fmap unSingle <$> rawSql "SELECT DISTINCT projection_id FROM events" []
-
-sqlGetAggregateEvents
-  :: (MonadIO m)
-  => UUID -> Maybe EventVersion -> ReaderT SqlBackend m [StoredEvent JSONString]
-sqlGetAggregateEvents uuid mVers = do
-  let
-    constraints =
-      (SqlEventProjectionId ==. uuid) :
-      maybe [] (\vers -> [SqlEventVersion >=. vers]) mVers
-  entities <- selectList constraints [Asc SqlEventVersion]
-  return $ sqlEventToStored . entityVal <$> entities
-
-sqlGetAllEventsFromSequence
-  :: (MonadIO m)
-  => SequenceNumber -> ReaderT SqlBackend m [GloballyOrderedEvent (StoredEvent JSONString)]
-sqlGetAllEventsFromSequence seqNum = do
-  entities <- selectList [SqlEventId >=. SqlEventKey seqNum] [Asc SqlEventId]
-  return $ sqlEventToGloballyOrdered <$> entities
-
-sqlMaxEventVersion :: (MonadIO m) => Text -> UUID -> ReaderT SqlBackend m EventVersion
-sqlMaxEventVersion maxVersionSql uuid =
-  let rawVals = rawSql maxVersionSql [toPersistValue uuid]
-  in maybe 0 unSingle . listToMaybe <$> rawVals
-
-sqlStoreEvents :: (MonadIO m) => Text -> ([SqlEvent] -> SqlPersistT m ()) -> UUID -> [JSONString] -> SqlPersistT m ()
-sqlStoreEvents maxVersionSql bulkInsert uuid events = do
-  versionNum <- sqlMaxEventVersion maxVersionSql uuid
-  let entities = zipWith (SqlEvent uuid) [versionNum + 1..] events
-  bulkInsert entities

--- a/eventful-sql-common/src/Eventful/Store/Sql/DefaultEntity.hs
+++ b/eventful-sql-common/src/Eventful/Store/Sql/DefaultEntity.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+-- | Definition for a default Entity to use with a SQL event store.
+
+module Eventful.Store.Sql.DefaultEntity
+  ( SqlEvent (..)
+  , SqlEventId
+  , migrateSqlEvent
+  , defaultSqlEventStoreConfig
+  ) where
+
+import Database.Persist.TH
+
+import Eventful.Store.Class
+import Eventful.UUID
+
+import Eventful.Store.Sql.Operations
+import Eventful.Store.Sql.JSONString
+import Eventful.Store.Sql.Orphans ()
+
+share [mkPersist sqlSettings, mkMigrate "migrateSqlEvent"] [persistLowerCase|
+SqlEvent sql=events
+    Id SequenceNumber sql=sequence_number
+    uuid UUID
+    version EventVersion
+    event JSONString
+    UniqueAggregateVersion uuid version
+    deriving Show
+|]
+
+defaultSqlEventStoreConfig :: SqlEventStoreConfig SqlEvent JSONString
+defaultSqlEventStoreConfig =
+  SqlEventStoreConfig
+  SqlEvent
+  SqlEventKey
+  (\(SqlEventKey seqNum) -> seqNum)
+  sqlEventUuid
+  sqlEventVersion
+  sqlEventEvent
+  SqlEventId
+  SqlEventUuid
+  SqlEventVersion
+  SqlEventEvent

--- a/eventful-sql-common/src/Eventful/Store/Sql/Operations.hs
+++ b/eventful-sql-common/src/Eventful/Store/Sql/Operations.hs
@@ -38,10 +38,9 @@ data SqlEventStoreConfig entity serialized =
 
 sqlGetGloballyOrderedEvents
   :: (MonadIO m, PersistEntity entity, PersistEntityBackend entity ~ SqlBackend)
-  => SqlEventStoreConfig entity serialized
-  -> GetGloballyOrderedEvents () (StoredEvent serialized) (SqlPersistT m)
-sqlGetGloballyOrderedEvents config =
-  GetGloballyOrderedEvents $ const $ sqlGetAllEventsFromSequence config
+  => GetGloballyOrderedEvents (SqlEventStoreConfig entity serialized) (StoredEvent serialized) (SqlPersistT m)
+sqlGetGloballyOrderedEvents =
+  GetGloballyOrderedEvents sqlGetAllEventsFromSequence
 
 sqlEventToGloballyOrdered
   :: SqlEventStoreConfig entity serialized

--- a/eventful-sql-common/src/Eventful/Store/Sql/Operations.hs
+++ b/eventful-sql-common/src/Eventful/Store/Sql/Operations.hs
@@ -1,0 +1,124 @@
+module Eventful.Store.Sql.Operations
+  ( SqlEventStoreConfig (..)
+  , sqlGetGloballyOrderedEvents
+  , sqlGetProjectionIds
+  , sqlGetAggregateEvents
+  , sqlMaxEventVersion
+  , sqlStoreEvents
+  ) where
+
+import Control.Monad.Reader
+import Data.Maybe (listToMaybe, maybe)
+import Data.Monoid ((<>))
+import Data.Text (Text)
+import Database.Persist
+import Database.Persist.Sql
+
+import Eventful.Store.Class
+import Eventful.UUID
+
+import Eventful.Store.Sql.Orphans as X ()
+
+data SqlEventStoreConfig entity serialized =
+  SqlEventStoreConfig
+  { sqlEventStoreConfigSequenceMakeEntity :: UUID -> EventVersion -> serialized -> entity
+    -- Key manipulation
+  , sqlEventStoreConfigMakeKey :: SequenceNumber -> Key entity
+  , sqlEventStoreConfigUnKey :: Key entity -> SequenceNumber
+    -- Record functions
+  , sqlEventStoreConfigUUID :: entity -> UUID
+  , sqlEventStoreConfigVersion :: entity -> EventVersion
+  , sqlEventStoreConfigData :: entity -> serialized
+    -- EntityFields
+  , sqlEventStoreConfigSequenceNumberField :: EntityField entity (Key entity)
+  , sqlEventStoreConfigUUIDField :: EntityField entity UUID
+  , sqlEventStoreConfigVersionField :: EntityField entity EventVersion
+  , sqlEventStoreConfigDataField :: EntityField entity serialized
+  }
+
+sqlGetGloballyOrderedEvents
+  :: (MonadIO m, PersistEntity entity, PersistEntityBackend entity ~ SqlBackend)
+  => SqlEventStoreConfig entity serialized
+  -> GetGloballyOrderedEvents () (StoredEvent serialized) (SqlPersistT m)
+sqlGetGloballyOrderedEvents config =
+  GetGloballyOrderedEvents $ const $ sqlGetAllEventsFromSequence config
+
+sqlEventToGloballyOrdered
+  :: SqlEventStoreConfig entity serialized
+  -> Entity entity
+  -> GloballyOrderedEvent (StoredEvent serialized)
+sqlEventToGloballyOrdered config@SqlEventStoreConfig{..} (Entity key event) =
+  GloballyOrderedEvent (sqlEventStoreConfigUnKey key) $ sqlEventToStored config event
+
+sqlEventToStored
+  :: SqlEventStoreConfig entity serialized
+  -> entity
+  -> StoredEvent serialized
+sqlEventToStored SqlEventStoreConfig{..} entity =
+  StoredEvent
+  (sqlEventStoreConfigUUID entity)
+  (sqlEventStoreConfigVersion entity)
+  (sqlEventStoreConfigData entity)
+
+sqlGetProjectionIds
+  :: (MonadIO m, PersistEntity entity, PersistEntityBackend entity ~ SqlBackend)
+  => SqlEventStoreConfig entity serialized
+  -> SqlPersistT m [UUID]
+sqlGetProjectionIds SqlEventStoreConfig{..} =
+  fmap unSingle <$> rawSql ("SELECT DISTINCT " <> uuidFieldName <> " FROM " <> tableName) []
+  where
+    (DBName tableName) = tableDBName (sqlEventStoreConfigSequenceMakeEntity nil 0 undefined)
+    (DBName uuidFieldName) = fieldDBName sqlEventStoreConfigSequenceNumberField
+
+sqlGetAggregateEvents
+  :: (MonadIO m, PersistEntity entity, PersistEntityBackend entity ~ SqlBackend)
+  => SqlEventStoreConfig entity serialized
+  -> UUID
+  -> Maybe EventVersion
+  -> SqlPersistT m [StoredEvent serialized]
+sqlGetAggregateEvents config@SqlEventStoreConfig{..} uuid mVers = do
+  let
+    constraints =
+      (sqlEventStoreConfigUUIDField ==. uuid) :
+      maybe [] (\vers -> [sqlEventStoreConfigVersionField >=. vers]) mVers
+  entities <- selectList constraints [Asc sqlEventStoreConfigVersionField]
+  return $ sqlEventToStored config . entityVal <$> entities
+
+sqlGetAllEventsFromSequence
+  :: (MonadIO m, PersistEntity entity, PersistEntityBackend entity ~ SqlBackend)
+  => SqlEventStoreConfig entity serialized
+  -> SequenceNumber
+  -> SqlPersistT m [GloballyOrderedEvent (StoredEvent serialized)]
+sqlGetAllEventsFromSequence config@SqlEventStoreConfig{..} seqNum = do
+  entities <-
+    selectList
+    [sqlEventStoreConfigSequenceNumberField >=. sqlEventStoreConfigMakeKey seqNum]
+    [Asc sqlEventStoreConfigSequenceNumberField]
+  return $ sqlEventToGloballyOrdered config <$> entities
+
+sqlMaxEventVersion
+  :: (MonadIO m, PersistEntity entity, PersistEntityBackend entity ~ SqlBackend)
+  => SqlEventStoreConfig entity serialized
+  -> (DBName -> DBName -> DBName -> Text)
+  -> UUID
+  -> SqlPersistT m EventVersion
+sqlMaxEventVersion SqlEventStoreConfig{..} maxVersionSql uuid =
+  let
+    tableName = tableDBName (sqlEventStoreConfigSequenceMakeEntity nil 0 undefined)
+    uuidFieldName = fieldDBName sqlEventStoreConfigUUIDField
+    versionFieldName = fieldDBName sqlEventStoreConfigVersionField
+    rawVals = rawSql (maxVersionSql tableName uuidFieldName versionFieldName) [toPersistValue uuid]
+  in maybe 0 unSingle . listToMaybe <$> rawVals
+
+sqlStoreEvents
+  :: (MonadIO m, PersistEntity entity, PersistEntityBackend entity ~ SqlBackend)
+  => SqlEventStoreConfig entity serialized
+  -> (DBName -> DBName -> DBName -> Text)
+  -> ([entity] -> SqlPersistT m ())
+  -> UUID
+  -> [serialized]
+  -> SqlPersistT m ()
+sqlStoreEvents config@SqlEventStoreConfig{..} maxVersionSql bulkInsert uuid events = do
+  versionNum <- sqlMaxEventVersion config maxVersionSql uuid
+  let entities = zipWith (sqlEventStoreConfigSequenceMakeEntity uuid) [versionNum + 1..] events
+  bulkInsert entities

--- a/eventful-sqlite/package.yaml
+++ b/eventful-sqlite/package.yaml
@@ -23,6 +23,7 @@ dependencies:
   - persistent
   - persistent-sqlite
   - split
+  - text
   - uuid
 
 default-extensions:

--- a/eventful-sqlite/src/Eventful/Store/Sqlite.hs
+++ b/eventful-sqlite/src/Eventful/Store/Sqlite.hs
@@ -7,10 +7,8 @@ module Eventful.Store.Sqlite
   , initializeSqliteEventStore
   , bulkInsert
   , sqliteMaxVariableNumber
-  , sqlGetGloballyOrderedEvents
-  , JSONString
-  , defaultSqlEventStoreConfig
   , module Eventful.Store.Class
+  , module Eventful.Store.Sql
   ) where
 
 import Control.Monad.Reader
@@ -23,25 +21,25 @@ import Database.Persist.Sql
 import Eventful.Store.Class
 import Eventful.Store.Sql
 
--- | The @store@ for SQLite is currently the @Unit@ type @()@. That is, all the
--- info we need to run an SQLite event store is presumably stored in the
--- database connection. In the future this will probably hold information like
--- what tables are used to store events, and could hold type information if we
--- allow the user to select the serialization method.
-type SqliteEventStore m = EventStore () JSONString (SqlPersistT m)
+-- | A 'SqliteEventStore' holds a 'SqlEventStoreConfig', which is where the
+-- store gets info about the events table.
+type SqliteEventStore entity serialized m = EventStore (SqlEventStoreConfig entity serialized) serialized (SqlPersistT m)
 
-type SqliteEventStoreT m = EventStoreT () JSONString (SqlPersistT m)
+type SqliteEventStoreT entity serialized m = EventStoreT (SqlEventStoreConfig entity serialized) serialized (SqlPersistT m)
 
-sqliteEventStore :: (MonadIO m) => SqliteEventStore m
-sqliteEventStore =
+sqliteEventStore
+  :: (MonadIO m, PersistEntity entity, PersistEntityBackend entity ~ SqlBackend)
+  => SqlEventStoreConfig entity serialized
+  -> SqliteEventStore entity serialized m
+sqliteEventStore config =
   let
-    getAllUuidsRaw () = sqlGetProjectionIds defaultSqlEventStoreConfig
-    getLatestVersionRaw () = sqlMaxEventVersion defaultSqlEventStoreConfig maxSqliteVersionSql
-    getEventsRaw () uuid = sqlGetAggregateEvents defaultSqlEventStoreConfig uuid Nothing
-    getEventsFromVersionRaw () uuid vers = sqlGetAggregateEvents defaultSqlEventStoreConfig uuid (Just vers)
-    storeEventsRaw' () = sqlStoreEvents defaultSqlEventStoreConfig maxSqliteVersionSql (bulkInsert 4)
+    getAllUuidsRaw = sqlGetProjectionIds
+    getLatestVersionRaw config' = sqlMaxEventVersion config' maxSqliteVersionSql
+    getEventsRaw config' uuid = sqlGetAggregateEvents config' uuid Nothing
+    getEventsFromVersionRaw config' uuid vers = sqlGetAggregateEvents config' uuid (Just vers)
+    storeEventsRaw' config' = sqlStoreEvents config' maxSqliteVersionSql (bulkInsert 4)
     storeEventsRaw = transactionalExpectedWriteHelper getLatestVersionRaw storeEventsRaw'
-  in EventStore () EventStoreDefinition{..}
+  in EventStore config EventStoreDefinition{..}
 
 maxSqliteVersionSql :: DBName -> DBName -> DBName -> Text
 maxSqliteVersionSql (DBName tableName) (DBName uuidFieldName) (DBName versionFieldName) =
@@ -66,20 +64,24 @@ bulkInsert numFields items = forM_ (chunksOf chunkSize items) insertMany_
 sqliteMaxVariableNumber :: Int
 sqliteMaxVariableNumber = 999
 
-initializeSqliteEventStore :: (MonadIO m) => ConnectionPool -> m ()
-initializeSqliteEventStore pool = do
+initializeSqliteEventStore
+  :: (MonadIO m, PersistEntity entity, PersistEntityBackend entity ~ SqlBackend)
+  => SqlEventStoreConfig entity serialized
+  -> ConnectionPool
+  -> m ()
+initializeSqliteEventStore SqlEventStoreConfig{..} pool = do
   -- Run migrations
   _ <- liftIO $ runSqlPool (runMigrationSilent migrateSqlEvent) pool
 
-  -- Create index on projection_id so retrieval is very fast
+  -- Create index on uuid field so retrieval is very fast
   let
-    uuidColumn = unDBName $ fieldDBName (sqlEventStoreConfigUUIDField defaultSqlEventStoreConfig)
+    (DBName tableName) = tableDBName (sqlEventStoreConfigSequenceMakeEntity undefined undefined undefined)
+    (DBName uuidFieldName) = fieldDBName sqlEventStoreConfigSequenceNumberField
     indexSql =
       "CREATE INDEX IF NOT EXISTS " <>
-      uuidColumn <> "_index" <>
-      " ON events (" <>
-      uuidColumn <>
-      ")"
+      uuidFieldName <> "_index" <>
+      " ON " <> tableName <>
+      " (" <> uuidFieldName <> ")"
   liftIO $ flip runSqlPool pool $ rawExecute indexSql []
 
   return ()

--- a/eventful-sqlite/tests/Eventful/Store/SqliteSpec.hs
+++ b/eventful-sqlite/tests/Eventful/Store/SqliteSpec.hs
@@ -7,17 +7,18 @@ import Test.Hspec
 import Eventful.Store.Sqlite
 import Eventful.TestHelpers
 
-makeStore :: (MonadIO m) => m (SqliteEventStore m, ConnectionPool)
+makeStore :: (MonadIO m) => m (SqliteEventStore SqlEvent JSONString m, ConnectionPool)
 makeStore = do
   pool <- liftIO $ runNoLoggingT (createSqlitePool ":memory:" 1)
-  initializeSqliteEventStore pool
-  return (sqliteEventStore, pool)
+  let store = sqliteEventStore defaultSqlEventStoreConfig
+  initializeSqliteEventStore defaultSqlEventStoreConfig pool
+  return (store, pool)
 
 spec :: Spec
 spec = do
   describe "Sqlite event store" $ do
     eventStoreSpec makeStore (flip runSqlPool)
-    sequencedEventStoreSpec (sqlGetGloballyOrderedEvents defaultSqlEventStoreConfig) makeStore (flip runSqlPool)
+    sequencedEventStoreSpec sqlGetGloballyOrderedEvents makeStore (flip runSqlPool)
 
     context "when inserting more than SQLITE_MAX_VARIABLE_NUMBER events" $ do
       (store, pool) <- runIO makeStore

--- a/eventful-sqlite/tests/Eventful/Store/SqliteSpec.hs
+++ b/eventful-sqlite/tests/Eventful/Store/SqliteSpec.hs
@@ -17,7 +17,7 @@ spec :: Spec
 spec = do
   describe "Sqlite event store" $ do
     eventStoreSpec makeStore (flip runSqlPool)
-    sequencedEventStoreSpec sqlGetGloballyOrderedEvents makeStore (flip runSqlPool)
+    sequencedEventStoreSpec (sqlGetGloballyOrderedEvents defaultSqlEventStoreConfig) makeStore (flip runSqlPool)
 
     context "when inserting more than SQLITE_MAX_VARIABLE_NUMBER events" $ do
       (store, pool) <- runIO makeStore

--- a/examples/cafe/src/Cafe/CLI.hs
+++ b/examples/cafe/src/Cafe/CLI.hs
@@ -26,7 +26,7 @@ cliMain = do
 
   -- Set up DB connection
   pool <- runNoLoggingT $ createSqlitePool (pack optionsDatabaseFile) 1
-  initializeSqliteEventStore pool
+  initializeSqliteEventStore defaultSqlEventStoreConfig pool
   void $ liftIO $ runSqlPool (runMigrationSilent migrateTabEntity) pool
 
   runCLI pool (runCLICommand optionsCommand)

--- a/examples/cafe/src/Cafe/CLI/Transformer.hs
+++ b/examples/cafe/src/Cafe/CLI/Transformer.hs
@@ -25,5 +25,5 @@ runDB query = do
   liftIO $ runSqlPool query pool
 
 -- | Run a given event store action.
-runEventStoreCLI :: EventStoreT () JSONString (SqlPersistT IO) a -> CLI a
-runEventStoreCLI = runDB . runEventStore sqliteEventStore
+runEventStoreCLI :: EventStoreT (SqlEventStoreConfig SqlEvent JSONString) JSONString (SqlPersistT IO) a -> CLI a
+runEventStoreCLI = runDB . runEventStore (sqliteEventStore defaultSqlEventStoreConfig)

--- a/examples/cafe/src/Cafe/ChefTodoList.hs
+++ b/examples/cafe/src/Cafe/ChefTodoList.hs
@@ -29,7 +29,7 @@ chefTodoListMain = do
   dbFilePath <- execParser $ info (helper <*> parseDatabaseFileOption) (fullDesc <> progDesc "Chef Todo List Terminal")
   pool <- runNoLoggingT $ createSqlitePool (pack dbFilePath) 1
   readModel <- memoryReadModel Map.empty applyChefReadModelEvents
-  runPollingReadModel readModel sqliteEventStore sqlGetGloballyOrderedEvents (`runSqlPool` pool) 1
+  runPollingReadModel readModel sqliteEventStore (sqlGetGloballyOrderedEvents defaultSqlEventStoreConfig) (`runSqlPool` pool) 1
 
 applyChefReadModelEvents
   :: Map UUID [Maybe Food]

--- a/examples/cafe/src/Cafe/ChefTodoList.hs
+++ b/examples/cafe/src/Cafe/ChefTodoList.hs
@@ -29,7 +29,7 @@ chefTodoListMain = do
   dbFilePath <- execParser $ info (helper <*> parseDatabaseFileOption) (fullDesc <> progDesc "Chef Todo List Terminal")
   pool <- runNoLoggingT $ createSqlitePool (pack dbFilePath) 1
   readModel <- memoryReadModel Map.empty applyChefReadModelEvents
-  runPollingReadModel readModel sqliteEventStore (sqlGetGloballyOrderedEvents defaultSqlEventStoreConfig) (`runSqlPool` pool) 1
+  runPollingReadModel readModel (sqliteEventStore defaultSqlEventStoreConfig) sqlGetGloballyOrderedEvents (`runSqlPool` pool) 1
 
 applyChefReadModelEvents
   :: Map UUID [Maybe Food]


### PR DESCRIPTION
We don't want people to have to use our hard-coded table name, serialization type, column names, etc.