### PR TITLE
Serialize DynamoDB values to aeson's Value

### DIFF
--- a/eventful-dynamodb/package.yaml
+++ b/eventful-dynamodb/package.yaml
@@ -20,6 +20,7 @@ dependencies:
   - safe
   - text
   - unordered-containers
+  - vector
 
 default-extensions:
   - ConstraintKinds
@@ -56,6 +57,8 @@ tests:
     dependencies:
       - hspec
       - HUnit
+      - QuickCheck
+      - quickcheck-instances
       - eventful-test-helpers
   style:
     main: HLint.hs

--- a/eventful-dynamodb/src/Eventful/Store/DynamoDB.hs
+++ b/eventful-dynamodb/src/Eventful/Store/DynamoDB.hs
@@ -32,27 +32,34 @@ import System.IO
 
 import Eventful.Store.DynamoDB.DynamoJSON
 
-type DynamoDBEventStore m = EventStore DynamoDBEventStoreConfig Value m
-type DynamoDBEventStoreT m = EventStoreT DynamoDBEventStoreConfig Value m
+type DynamoDBEventStore serialized m = EventStore (DynamoDBEventStoreConfig serialized) serialized m
+type DynamoDBEventStoreT serialized m = EventStoreT (DynamoDBEventStoreConfig serialized) serialized m
 
-data DynamoDBEventStoreConfig =
+data DynamoDBEventStoreConfig serialized =
   DynamoDBEventStoreConfig
   { dynamoDBEventStoreConfigTableName :: Text
-  , dynamoDBEventStoreUUIDAttributeName :: Text
-  , dynamoDBEventStoreVersionAttributeName :: Text
-  , dynamoDBEventStoreEventAttributeName :: Text
-  } deriving (Show)
+  , dynamoDBEventStoreConfigUUIDAttributeName :: Text
+  , dynamoDBEventStoreConfigVersionAttributeName :: Text
+  , dynamoDBEventStoreConfigEventAttributeName :: Text
+  , dynamoDBEventStoreConfigSerializedToValue :: serialized -> AttributeValue
+  , dynamoDBEventStoreConfigValueToSerialized :: AttributeValue -> serialized
+  }
 
-defaultDynamoDBEventStoreConfig :: DynamoDBEventStoreConfig
+defaultDynamoDBEventStoreConfig :: DynamoDBEventStoreConfig Value
 defaultDynamoDBEventStoreConfig =
   DynamoDBEventStoreConfig
   { dynamoDBEventStoreConfigTableName = "Events"
-  , dynamoDBEventStoreUUIDAttributeName = "UUID"
-  , dynamoDBEventStoreVersionAttributeName = "Version"
-  , dynamoDBEventStoreEventAttributeName = "Event"
+  , dynamoDBEventStoreConfigUUIDAttributeName = "UUID"
+  , dynamoDBEventStoreConfigVersionAttributeName = "Version"
+  , dynamoDBEventStoreConfigEventAttributeName = "Event"
+  , dynamoDBEventStoreConfigSerializedToValue = valueToAttributeValue
+  , dynamoDBEventStoreConfigValueToSerialized = attributeValueToValue
   }
 
-dynamoDBEventStore :: (MonadAWS m) => DynamoDBEventStoreConfig -> DynamoDBEventStore m
+dynamoDBEventStore
+  :: (MonadAWS m)
+  => DynamoDBEventStoreConfig serialized
+  -> DynamoDBEventStore serialized m
 dynamoDBEventStore config =
   let
     getLatestVersionRaw = latestEventVersion
@@ -62,7 +69,12 @@ dynamoDBEventStore config =
     storeEventsRaw = transactionalExpectedWriteHelper getLatestVersionRaw storeEventsRaw'
   in EventStore config EventStoreDefinition{..}
 
-getDynamoEvents :: (MonadAWS m) => DynamoDBEventStoreConfig -> UUID -> Maybe EventVersion -> m [StoredEvent Value]
+getDynamoEvents
+  :: (MonadAWS m)
+  => DynamoDBEventStoreConfig serialized
+  -> UUID
+  -> Maybe EventVersion
+  -> m [StoredEvent serialized]
 getDynamoEvents config@DynamoDBEventStoreConfig{..} uuid mStartingVersion = do
   latestEvents <-
     paginate (queryBase config uuid mStartingVersion) =$=
@@ -70,16 +82,24 @@ getDynamoEvents config@DynamoDBEventStoreConfig{..} uuid mStartingVersion = do
     CL.consume
   return $ mapMaybe (decodeDynamoEvent config uuid) latestEvents
 
-decodeDynamoEvent :: DynamoDBEventStoreConfig -> UUID -> HashMap Text AttributeValue -> Maybe (StoredEvent Value)
+decodeDynamoEvent
+  :: DynamoDBEventStoreConfig serialized
+  -> UUID
+  -> HashMap Text AttributeValue
+  -> Maybe (StoredEvent serialized)
 decodeDynamoEvent DynamoDBEventStoreConfig{..} uuid attributeMap = do
-  versionValue <- HM.lookup dynamoDBEventStoreVersionAttributeName attributeMap
+  versionValue <- HM.lookup dynamoDBEventStoreConfigVersionAttributeName attributeMap
   versionText <- versionValue ^. avN
   version <- EventVersion <$> readMay (T.unpack versionText)
-  eventAttributeValue <- HM.lookup dynamoDBEventStoreEventAttributeName attributeMap
-  let event = attributeValueToValue eventAttributeValue
+  eventAttributeValue <- HM.lookup dynamoDBEventStoreConfigEventAttributeName attributeMap
+  let event = dynamoDBEventStoreConfigValueToSerialized eventAttributeValue
   return $ StoredEvent uuid version event
 
-latestEventVersion :: (MonadAWS m) => DynamoDBEventStoreConfig -> UUID -> m EventVersion
+latestEventVersion
+  :: (MonadAWS m)
+  => DynamoDBEventStoreConfig serialized
+  -> UUID
+  -> m EventVersion
 latestEventVersion config@DynamoDBEventStoreConfig{..} uuid = do
   latestEvents <- fmap (view qrsItems) . send $
     queryBase config uuid Nothing
@@ -88,30 +108,39 @@ latestEventVersion config@DynamoDBEventStoreConfig{..} uuid = do
   return $ EventVersion $ fromMaybe (-1) $ do
     -- NB: We are in the Maybe monad here
     attributeMap <- headMay latestEvents
-    versionValue <- HM.lookup dynamoDBEventStoreVersionAttributeName attributeMap
+    versionValue <- HM.lookup dynamoDBEventStoreConfigVersionAttributeName attributeMap
     version <- versionValue ^. avN
     readMay $ T.unpack version
 
 -- | Convenience function to create a Query value for a given store config and
 -- UUID.
-queryBase :: DynamoDBEventStoreConfig -> UUID -> Maybe EventVersion -> Query
+queryBase
+  :: DynamoDBEventStoreConfig serialized
+  -> UUID
+  -> Maybe EventVersion
+  -> Query
 queryBase DynamoDBEventStoreConfig{..} uuid mStartingVersion =
   query
   dynamoDBEventStoreConfigTableName
   & qKeyConditionExpression ?~ "#uuid = :uuid" <> versionCaseExpression
   & qExpressionAttributeNames .~
-    HM.singleton "#uuid" dynamoDBEventStoreUUIDAttributeName <>
+    HM.singleton "#uuid" dynamoDBEventStoreConfigUUIDAttributeName <>
     versionVariableName
   & qExpressionAttributeValues .~
     HM.singleton ":uuid" (attributeValue & avS ?~ uuidToText uuid) <>
     versionAttributeValue
   where
     versionCaseExpression = maybe "" (const " AND #version >= :version") mStartingVersion
-    versionVariableName = maybe HM.empty (const $ HM.singleton "#version" dynamoDBEventStoreVersionAttributeName) mStartingVersion
+    versionVariableName = maybe HM.empty (const $ HM.singleton "#version" dynamoDBEventStoreConfigVersionAttributeName) mStartingVersion
     versionAttributeValue = maybe HM.empty (HM.singleton ":version" . mkVersionValue) mStartingVersion
     mkVersionValue (EventVersion version) = attributeValue & avN ?~ T.pack (show version)
 
-storeDynamoEvents :: (MonadAWS m) => DynamoDBEventStoreConfig -> UUID -> [Value] -> m ()
+storeDynamoEvents
+  :: (MonadAWS m)
+  => DynamoDBEventStoreConfig serialized
+  -> UUID
+  -> [serialized]
+  -> m ()
 storeDynamoEvents config@DynamoDBEventStoreConfig{..} uuid events = do
   latestVersion <- latestEventVersion config uuid
 
@@ -122,9 +151,9 @@ storeDynamoEvents config@DynamoDBEventStoreConfig{..} uuid events = do
       dynamoDBEventStoreConfigTableName
       & piItem .~
         HM.fromList
-        [ (dynamoDBEventStoreUUIDAttributeName, attributeValue & avS ?~ uuidToText uuid)
-        , (dynamoDBEventStoreVersionAttributeName, attributeValue & avN ?~ T.pack (show version))
-        , (dynamoDBEventStoreEventAttributeName, valueToAttributeValue event)
+        [ (dynamoDBEventStoreConfigUUIDAttributeName, attributeValue & avS ?~ uuidToText uuid)
+        , (dynamoDBEventStoreConfigVersionAttributeName, attributeValue & avN ?~ T.pack (show version))
+        , (dynamoDBEventStoreConfigEventAttributeName, dynamoDBEventStoreConfigSerializedToValue event)
         ]
 
 -- | Helpful function to create the events table. If a table already exists
@@ -132,7 +161,7 @@ storeDynamoEvents config@DynamoDBEventStoreConfig{..} uuid events = do
 -- no magic migrations going on here, trust this function at your own risk.
 initializeDynamoDBEventStore
   :: (MonadAWS m)
-  => DynamoDBEventStoreConfig
+  => DynamoDBEventStoreConfig serialized
   -> ProvisionedThroughput
   -> m ()
 initializeDynamoDBEventStore config@DynamoDBEventStoreConfig{..} throughput = do
@@ -146,17 +175,17 @@ initializeDynamoDBEventStore config@DynamoDBEventStoreConfig{..} throughput = do
       & ctAttributeDefinitions .~ attributeDefs
     void $ await tableExists (describeTable dynamoDBEventStoreConfigTableName)
   where
-    uuidKey = keySchemaElement dynamoDBEventStoreUUIDAttributeName Hash
-    versionKey = keySchemaElement dynamoDBEventStoreVersionAttributeName Range
+    uuidKey = keySchemaElement dynamoDBEventStoreConfigUUIDAttributeName Hash
+    versionKey = keySchemaElement dynamoDBEventStoreConfigVersionAttributeName Range
     attributeDefs =
-      [ attributeDefinition dynamoDBEventStoreUUIDAttributeName S
-      , attributeDefinition dynamoDBEventStoreVersionAttributeName N
+      [ attributeDefinition dynamoDBEventStoreConfigUUIDAttributeName S
+      , attributeDefinition dynamoDBEventStoreConfigVersionAttributeName N
       ]
 
 -- | Checks if the table for the event store exists.
 getDynamoDBEventStoreTableExistence
   :: (MonadAWS m)
-  => DynamoDBEventStoreConfig
+  => DynamoDBEventStoreConfig serialized
   -> m Bool
 getDynamoDBEventStoreTableExistence DynamoDBEventStoreConfig{..} = do
   tablesResponse <- trying _ServiceError $ send $
@@ -173,7 +202,7 @@ getDynamoDBEventStoreTableExistence DynamoDBEventStoreConfig{..} = do
 -- testing this library.
 deleteDynamoDBEventStoreTable
   :: (MonadAWS m)
-  => DynamoDBEventStoreConfig
+  => DynamoDBEventStoreConfig serialized
   -> m ()
 deleteDynamoDBEventStoreTable config@DynamoDBEventStoreConfig{..} = do
   eventTableExists <- getDynamoDBEventStoreTableExistence config

--- a/eventful-dynamodb/src/Eventful/Store/DynamoDB/DynamoJSON.hs
+++ b/eventful-dynamodb/src/Eventful/Store/DynamoDB/DynamoJSON.hs
@@ -10,22 +10,28 @@ import qualified Data.Text as T
 import qualified Data.Vector as V
 import Network.AWS.DynamoDB hiding (Null)
 
+-- | Note, currently we can't properly disambiguate between an empty Object or
+-- an empty Array because of amazonka's 'AttributeValue' lenses. We use a very
+-- nasty kludge where we replace empty Objects with a string with a very
+-- special value. Follow this issue to see when we can remove the kludge:
+-- https://github.com/brendanhay/amazonka/issues/282.
 valueToAttributeValue :: Value -> AttributeValue
-valueToAttributeValue (String v)  = attributeValue & avS ?~ v
-valueToAttributeValue (Number v)  = attributeValue & avN ?~ T.pack (show v)
-valueToAttributeValue (Bool v)    = attributeValue & avBOOL ?~ v
-valueToAttributeValue (Array vs)  = attributeValue & avL .~ fmap valueToAttributeValue (V.toList vs)
-valueToAttributeValue (Object v)  = attributeValue & avM .~ fmap valueToAttributeValue v
-valueToAttributeValue Null        = attributeValue & avNULL ?~ True
+valueToAttributeValue (String v) = attributeValue & avS ?~ v
+valueToAttributeValue (Number v) = attributeValue & avN ?~ T.pack (show v)
+valueToAttributeValue (Bool v) = attributeValue & avBOOL ?~ v
+valueToAttributeValue (Array vs) = attributeValue & avL .~ fmap valueToAttributeValue (V.toList vs)
+valueToAttributeValue (Object v)
+  | HM.null v = attributeValue & avS ?~ "__eventful-dynamodb-empty-object__"
+  | otherwise = attributeValue & avM .~ fmap valueToAttributeValue v
+valueToAttributeValue Null = attributeValue & avNULL ?~ True
 
 attributeValueToValue :: AttributeValue -> Value
 attributeValueToValue av
+  | Just "__eventful-dynamodb-empty-object__" <- av ^. avS = Object HM.empty
   | Just v <- av ^. avS = String v
   | Just v <- av ^. avN = Number $ read $ T.unpack v
   | Just v <- av ^. avBOOL = Bool v
   | Just _ <- av ^. avNULL = Null
-  -- TODO: Telling the difference between an empty array and an empty object is
-  -- not possible right now.
   | v <- av ^. avM, not (HM.null v) = Object $ fmap attributeValueToValue v
   | vs <- av ^. avL = Array $ V.fromList $ fmap attributeValueToValue vs
   | otherwise = Null

--- a/eventful-dynamodb/src/Eventful/Store/DynamoDB/DynamoJSON.hs
+++ b/eventful-dynamodb/src/Eventful/Store/DynamoDB/DynamoJSON.hs
@@ -1,31 +1,31 @@
 module Eventful.Store.DynamoDB.DynamoJSON
-  ( DynamoJSON (..)
+  ( valueToAttributeValue
+  , attributeValueToValue
   ) where
 
+import Control.Lens
 import Data.Aeson
-import Data.Text (Text)
-import qualified Data.Text.Lazy as TL
-import qualified Data.Text.Lazy.Encoding as TLE
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Text as T
+import qualified Data.Vector as V
+import Network.AWS.DynamoDB hiding (Null)
 
-import Eventful.Serializable
+valueToAttributeValue :: Value -> AttributeValue
+valueToAttributeValue (String v)  = attributeValue & avS ?~ v
+valueToAttributeValue (Number v)  = attributeValue & avN ?~ T.pack (show v)
+valueToAttributeValue (Bool v)    = attributeValue & avBOOL ?~ v
+valueToAttributeValue (Array vs)  = attributeValue & avL .~ fmap valueToAttributeValue (V.toList vs)
+valueToAttributeValue (Object v)  = attributeValue & avM .~ fmap valueToAttributeValue v
+valueToAttributeValue Null        = attributeValue & avNULL ?~ True
 
--- | A more specific type than just ByteString for JSON data.
-newtype DynamoJSON = DynamoJSON { unDynamoJSON :: Text }
-  deriving (Eq)
-
-instance Show DynamoJSON where
-  show = show . unDynamoJSON
-
-instance (ToJSON a, FromJSON a) => Serializable a DynamoJSON where
-  serialize = encodeJSON
-  deserialize = decodeJSON
-  deserializeEither = decodeJSONEither
-
-encodeJSON :: (ToJSON a) => a -> DynamoJSON
-encodeJSON = DynamoJSON . TL.toStrict . TLE.decodeUtf8 . encode
-
-decodeJSON :: (FromJSON a) => DynamoJSON -> Maybe a
-decodeJSON = decode . TLE.encodeUtf8 . TL.fromStrict . unDynamoJSON
-
-decodeJSONEither :: (FromJSON a) => DynamoJSON -> Either String a
-decodeJSONEither = eitherDecode . TLE.encodeUtf8 . TL.fromStrict . unDynamoJSON
+attributeValueToValue :: AttributeValue -> Value
+attributeValueToValue av
+  | Just v <- av ^. avS = String v
+  | Just v <- av ^. avN = Number $ read $ T.unpack v
+  | Just v <- av ^. avBOOL = Bool v
+  | Just _ <- av ^. avNULL = Null
+  -- TODO: Telling the difference between an empty array and an empty object is
+  -- not possible right now.
+  | v <- av ^. avM, not (HM.null v) = Object $ fmap attributeValueToValue v
+  | vs <- av ^. avL = Array $ V.fromList $ fmap attributeValueToValue vs
+  | otherwise = Null

--- a/eventful-dynamodb/tests/Eventful/Store/DynamoDB/DynamoJSONSpec.hs
+++ b/eventful-dynamodb/tests/Eventful/Store/DynamoDB/DynamoJSONSpec.hs
@@ -1,0 +1,44 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Eventful.Store.DynamoDB.DynamoJSONSpec (spec) where
+
+import Data.Aeson
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Vector as V
+import Test.Hspec
+import Test.QuickCheck
+import Test.QuickCheck.Instances ()
+
+import Eventful.Store.DynamoDB.DynamoJSON
+
+spec :: Spec
+spec = do
+  describe "Value <-> AttributeValue conversion" $ do
+    it "Value -> AttributeValue -> Value round trip is idempotent" $ property $
+      \value ->
+        let value' = removeEmptyObjects value
+        in attributeValueToValue (valueToAttributeValue value') == value'
+
+-- Can't handle empty objects right now
+removeEmptyObjects :: Value -> Value
+removeEmptyObjects (Object xs) =
+  if HM.null xs
+  then Array V.empty
+  else Object $ removeEmptyObjects <$> xs
+removeEmptyObjects (Array xs) = Array $ removeEmptyObjects <$> xs
+removeEmptyObjects x = x
+
+instance Arbitrary Value where
+  arbitrary = sized sizedArbitraryValue
+
+sizedArbitraryValue :: Int -> Gen Value
+sizedArbitraryValue n
+  | n <= 0 = oneof [pure Null, bool, number, string]
+  | otherwise = resize n' $ oneof [pure Null, bool, number, string, array, object']
+  where
+    n' = n `div` 2
+    bool = Bool <$> arbitrary
+    number = Number <$> arbitrary
+    string = String <$> arbitrary
+    array = Array <$> arbitrary
+    object' = Object <$> arbitrary

--- a/eventful-dynamodb/tests/Eventful/Store/DynamoDB/DynamoJSONSpec.hs
+++ b/eventful-dynamodb/tests/Eventful/Store/DynamoDB/DynamoJSONSpec.hs
@@ -3,8 +3,6 @@
 module Eventful.Store.DynamoDB.DynamoJSONSpec (spec) where
 
 import Data.Aeson
-import qualified Data.HashMap.Strict as HM
-import qualified Data.Vector as V
 import Test.Hspec
 import Test.QuickCheck
 import Test.QuickCheck.Instances ()
@@ -15,18 +13,7 @@ spec :: Spec
 spec = do
   describe "Value <-> AttributeValue conversion" $ do
     it "Value -> AttributeValue -> Value round trip is idempotent" $ property $
-      \value ->
-        let value' = removeEmptyObjects value
-        in attributeValueToValue (valueToAttributeValue value') == value'
-
--- Can't handle empty objects right now
-removeEmptyObjects :: Value -> Value
-removeEmptyObjects (Object xs) =
-  if HM.null xs
-  then Array V.empty
-  else Object $ removeEmptyObjects <$> xs
-removeEmptyObjects (Array xs) = Array $ removeEmptyObjects <$> xs
-removeEmptyObjects x = x
+      \value -> attributeValueToValue (valueToAttributeValue value) == value
 
 instance Arbitrary Value where
   arbitrary = sized sizedArbitraryValue

--- a/eventful-dynamodb/tests/Eventful/Store/DynamoDBSpec.hs
+++ b/eventful-dynamodb/tests/Eventful/Store/DynamoDBSpec.hs
@@ -1,6 +1,7 @@
 module Eventful.Store.DynamoDBSpec (spec) where
 
 import Control.Lens ((<&>))
+import Data.Aeson
 import Network.AWS
 import Network.AWS.DynamoDB
 import Test.Hspec
@@ -8,7 +9,7 @@ import Test.Hspec
 import Eventful.Store.DynamoDB
 import Eventful.TestHelpers
 
-makeStore :: IO (DynamoDBEventStore AWS, Env)
+makeStore :: IO (DynamoDBEventStore Value AWS, Env)
 makeStore = do
   let
     dynamo = setEndpoint False "localhost" 8000 dynamoDB


### PR DESCRIPTION
This works great except for one fatal flaw: right now the `amazonka-dynamodb` lenses for `AttributeValue` expose maps and lists in such a way that if they are not set, we don't see `Nothing`, but we see an empty container. For example, if our value is not a list, we don't get `Nothing` for `avL`, we get `[]`. This makes parsing an empty object or an empty array impossible because we can't tell which one we have. I arbitrarily chose to favor choosing empty arrays for now.

See https://github.com/brendanhay/amazonka/issues/282 to see if this can be fixed simply.