### PR TITLE
Simplify EventStore API, remove EventStoreT

### DIFF
--- a/eventful-core/src/Eventful/ReadModel/Class.hs
+++ b/eventful-core/src/Eventful/ReadModel/Class.hs
@@ -21,16 +21,14 @@ type PollingPeriodSeconds = Double
 runPollingReadModel
   :: (MonadIO m, Monad mstore)
   => ReadModel model serialized m
-  -> EventStore store serialized mstore
-  -> GetGloballyOrderedEvents store (StoredEvent serialized) mstore
+  -> GloballyOrderedEventStore serialized mstore
   -> (forall a. mstore a -> m a)
   -> PollingPeriodSeconds
   -> m ()
-runPollingReadModel ReadModel{..} eventStore getGloballyOrderedEvents runStore waitSeconds = forever $ do
+runPollingReadModel ReadModel{..} getGloballyOrderedEvents runStore waitSeconds = forever $ do
   -- Get new events starting from latest applied sequence number
   latestSeq <- readModelLatestAppliedSequence readModelModel
-  newEvents <- runStore . runEventStore eventStore $
-    getSequencedEvents getGloballyOrderedEvents (latestSeq + 1)
+  newEvents <- runStore $ getSequencedEvents getGloballyOrderedEvents (latestSeq + 1)
 
   -- Apply the new events
   readModelApplyEvents readModelModel newEvents

--- a/eventful-dynamodb/tests/Eventful/Store/DynamoDBSpec.hs
+++ b/eventful-dynamodb/tests/Eventful/Store/DynamoDBSpec.hs
@@ -6,10 +6,11 @@ import Network.AWS
 import Network.AWS.DynamoDB
 import Test.Hspec
 
+import Eventful.Store.Class
 import Eventful.Store.DynamoDB
 import Eventful.TestHelpers
 
-makeStore :: IO (DynamoDBEventStore Value AWS, Env)
+makeStore :: IO (EventStore Value AWS, Env)
 makeStore = do
   let
     dynamo = setEndpoint False "localhost" 8000 dynamoDB

--- a/eventful-memory/tests/Eventful/Store/MemorySpec.hs
+++ b/eventful-memory/tests/Eventful/Store/MemorySpec.hs
@@ -10,7 +10,14 @@ spec :: Spec
 spec = do
   describe "TVar memory event store" $ do
     eventStoreSpec makeStore (const atomically)
-    sequencedEventStoreSpec memoryGetGloballyOrderedEvents makeStore (const atomically)
+    sequencedEventStoreSpec makeGlobalStore (const atomically)
 
 makeStore :: IO (MemoryEventStore, ())
-makeStore = (,()) <$> memoryEventStore
+makeStore = do
+  (store, _, ()) <- makeGlobalStore
+  return (store, ())
+
+makeGlobalStore :: IO (MemoryEventStore, GloballyOrderedMemoryEventStore, ())
+makeGlobalStore = do
+  (store, globalStore) <- memoryEventStore
+  return (store, globalStore, ())

--- a/eventful-sql-common/src/Eventful/Store/Sql/Operations.hs
+++ b/eventful-sql-common/src/Eventful/Store/Sql/Operations.hs
@@ -1,6 +1,6 @@
 module Eventful.Store.Sql.Operations
   ( SqlEventStoreConfig (..)
-  , sqlGetGloballyOrderedEvents
+  , sqlGloballyOrderedEventStore
   , sqlGetProjectionIds
   , sqlGetAggregateEvents
   , sqlMaxEventVersion
@@ -36,11 +36,12 @@ data SqlEventStoreConfig entity serialized =
   , sqlEventStoreConfigDataField :: EntityField entity serialized
   }
 
-sqlGetGloballyOrderedEvents
+sqlGloballyOrderedEventStore
   :: (MonadIO m, PersistEntity entity, PersistEntityBackend entity ~ SqlBackend)
-  => GetGloballyOrderedEvents (SqlEventStoreConfig entity serialized) (StoredEvent serialized) (SqlPersistT m)
-sqlGetGloballyOrderedEvents =
-  GetGloballyOrderedEvents sqlGetAllEventsFromSequence
+  => SqlEventStoreConfig entity serialized
+  -> GloballyOrderedEventStore serialized (SqlPersistT m)
+sqlGloballyOrderedEventStore config =
+  GloballyOrderedEventStore $ sqlGetAllEventsFromSequence config
 
 sqlEventToGloballyOrdered
   :: SqlEventStoreConfig entity serialized

--- a/examples/cafe/src/Cafe/CLI.hs
+++ b/examples/cafe/src/Cafe/CLI.hs
@@ -43,16 +43,16 @@ runCLICommand ListMenu = liftIO $ do
   mapM_ printPair (zip [0 :: Int ..] $ map unDrink allDrinks)
 runCLICommand (ViewTab tabId) = do
   uuid <- fromJustNote "Could not find tab with given id" <$> runDB (getTabUuid tabId)
-  latest <- runEventStoreCLI $ getLatestProjection tabProjection uuid
+  latest <- runDB $ getLatestProjection cliEventStore tabProjection uuid
   liftIO $ printJSONPretty latest
 runCLICommand (TabCommand tabId command) = do
   uuid <- fromJustNote "Could not find tab with given id" <$> runDB (getTabUuid tabId)
-  result <- runEventStoreCLI $ commandStoredAggregate tabAggregate uuid command
+  result <- runDB $ commandStoredAggregate cliEventStore tabAggregate uuid command
   case result of
     Left err -> liftIO . putStrLn $ "Error! " ++ show err
     Right events -> do
       liftIO . putStrLn $ "Events: " ++ show events
-      latest <- runEventStoreCLI $ getLatestProjection tabProjection uuid
+      latest <- runDB $ getLatestProjection cliEventStore tabProjection uuid
       liftIO . putStrLn $ "Latest state:"
       liftIO $ printJSONPretty latest
 

--- a/examples/cafe/src/Cafe/CLI/Transformer.hs
+++ b/examples/cafe/src/Cafe/CLI/Transformer.hs
@@ -2,7 +2,8 @@ module Cafe.CLI.Transformer
   ( CLI
   , runCLI
   , runDB
-  , runEventStoreCLI
+  , cliEventStore
+  , cliGloballyOrderedEventStore
   ) where
 
 import Control.Monad.Reader
@@ -24,6 +25,8 @@ runDB query = do
   pool <- ask
   liftIO $ runSqlPool query pool
 
--- | Run a given event store action.
-runEventStoreCLI :: EventStoreT (SqlEventStoreConfig SqlEvent JSONString) JSONString (SqlPersistT IO) a -> CLI a
-runEventStoreCLI = runDB . runEventStore (sqliteEventStore defaultSqlEventStoreConfig)
+cliEventStore :: (MonadIO m) => EventStore JSONString (SqlPersistT m)
+cliEventStore = sqliteEventStore defaultSqlEventStoreConfig
+
+cliGloballyOrderedEventStore :: (MonadIO m) => GloballyOrderedEventStore JSONString (SqlPersistT m)
+cliGloballyOrderedEventStore = sqlGloballyOrderedEventStore defaultSqlEventStoreConfig

--- a/examples/cafe/src/Cafe/ChefTodoList.hs
+++ b/examples/cafe/src/Cafe/ChefTodoList.hs
@@ -20,6 +20,7 @@ import Eventful.ReadModel.Memory
 import Eventful.Store.Sqlite
 
 import Cafe.CLI.Options (parseDatabaseFileOption)
+import Cafe.CLI.Transformer
 import Cafe.Models.Tab
 
 -- | Create an in-memory read model that polls the SQLite event store and
@@ -29,7 +30,7 @@ chefTodoListMain = do
   dbFilePath <- execParser $ info (helper <*> parseDatabaseFileOption) (fullDesc <> progDesc "Chef Todo List Terminal")
   pool <- runNoLoggingT $ createSqlitePool (pack dbFilePath) 1
   readModel <- memoryReadModel Map.empty applyChefReadModelEvents
-  runPollingReadModel readModel (sqliteEventStore defaultSqlEventStoreConfig) sqlGetGloballyOrderedEvents (`runSqlPool` pool) 1
+  runPollingReadModel readModel cliGloballyOrderedEventStore (`runSqlPool` pool) 1
 
 applyChefReadModelEvents
   :: Map UUID [Maybe Food]

--- a/examples/counter-cli/counter-cli.hs
+++ b/examples/counter-cli/counter-cli.hs
@@ -15,7 +15,7 @@ import Eventful.Store.Memory
 main :: IO ()
 main = do
   -- Create the event store and run loop forever
-  store <- memoryEventStore
+  (store, _) <- memoryEventStore
   forever (readAndApplyCommand store)
 
 readAndApplyCommand :: MemoryEventStore -> IO ()
@@ -24,7 +24,7 @@ readAndApplyCommand store = do
   let uuid = nil
 
   -- Get current state and print it out
-  (currentState, _) <- atomically . runEventStore store $ getLatestProjection counterProjection uuid
+  (currentState, _) <- atomically $ getLatestProjection store counterProjection uuid
   putStrLn $ "Current state: " ++ show currentState
 
   -- Ask user for command
@@ -39,7 +39,7 @@ readAndApplyCommand store = do
         -- The command is valid. Apply the event to the store.
         Right events -> do
           putStrLn $ "Command valid. Event: " ++ show events
-          void . atomically . runEventStore store $ storeEvents AnyVersion uuid events
+          void . atomically $ storeEventsSerialized store AnyVersion uuid events
         -- The command is invalid. Show the user the error.
         Left err -> putStrLn $ "Command invalid: Error: " ++ show err
 


### PR DESCRIPTION
`EventStoreT` was really complicating things, so I removed it. It turns out it didn't actually do much at all for the API, since the API is now nicer, at least judging by the test suite.

The thing that sparked this change was I'm trying to allow users to have more control over serialization instead of forcing them to use `Serializable`. Now the event store API deals purely with events in the `serialized` type, so we don't have to force users to use e.g. `mapMaybe deserialize` (that is still provided as a convenience function though).

There's still room for improving the globally ordered event store API, but it's fine for now.