### PR TITLE
Add system to filter EventStore query results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.1.3
 
+* Added `EventStoreQueryRange` to the APIs of the event store and the globally
+  ordered event store. This allows the user to specify optional start and stop
+  points for the query.
 * Added versions of the `MonadState` event stores that can include other state
   along with the `EventMap`. These are called `embeddedStateEventStore` and
   `embeddedStateGloballyOrderedEventStore`.

--- a/doc/tutorial/EventStore.lhs
+++ b/doc/tutorial/EventStore.lhs
@@ -121,7 +121,7 @@ counterStoreExample = do
   _ <- atomically $ storeEvents store AnyVersion uuid events
 
   -- Now read the events back and print
-  events' <- atomically $ getEvents store uuid Nothing
+  events' <- atomically $ getEvents store uuid allEvents
   print events'
 ```
 

--- a/eventful-core/src/Eventful/Projection.hs
+++ b/eventful-core/src/Eventful/Projection.hs
@@ -61,7 +61,7 @@ getLatestProjection
   -> UUID
   -> m (proj, EventVersion)
 getLatestProjection store proj uuid = do
-  events <- getEvents store uuid Nothing
+  events <- getEvents store uuid allEvents
   let
     latestVersion = maxEventVersion events
     latestProj = latestProjection proj $ storedEventEvent <$> events
@@ -114,7 +114,7 @@ getLatestGlobalProjection
   -> GloballyOrderedProjection proj serialized
   -> m (GloballyOrderedProjection proj serialized)
 getLatestGlobalProjection store globalProjection@GloballyOrderedProjection{..} = do
-  events <- getSequencedEvents store (globallyOrderedProjectionSequenceNumber + 1)
+  events <- getSequencedEvents store (eventsStartingAt $ globallyOrderedProjectionSequenceNumber + 1)
   return $ foldl' globallyOrderedProjectionEventHandler globalProjection events
 
 -- | Use a 'Serializer' to wrap a 'Projection' with event type @event@ so it

--- a/eventful-core/src/Eventful/ReadModel/Class.hs
+++ b/eventful-core/src/Eventful/ReadModel/Class.hs
@@ -31,7 +31,7 @@ runPollingReadModel
 runPollingReadModel ReadModel{..} getGloballyOrderedEvents runStore waitSeconds = forever $ do
   -- Get new events starting from latest applied sequence number
   latestSeq <- readModelLatestAppliedSequence readModelModel
-  newEvents <- runStore $ getSequencedEvents getGloballyOrderedEvents (latestSeq + 1)
+  newEvents <- runStore $ getSequencedEvents getGloballyOrderedEvents (eventsStartingAt $ latestSeq + 1)
 
   -- Handle the new events
   readModelHandleEvents readModelModel newEvents

--- a/eventful-core/src/Eventful/Store/Class.hs
+++ b/eventful-core/src/Eventful/Store/Class.hs
@@ -10,6 +10,7 @@ module Eventful.Store.Class
   , GloballyOrderedEventStore (..)
   , ExpectedVersion (..)
   , EventWriteError (..)
+  , module Eventful.Store.Queries
     -- * Utility types
   , ProjectionEvent (..)
   , StoredEvent (..)
@@ -28,6 +29,7 @@ import Data.Aeson
 import Web.HttpApiData
 import Web.PathPieces
 
+import Eventful.Store.Queries
 import Eventful.UUID
 
 -- | The 'EventStore' is the core type of eventful. A store operates in some
@@ -36,7 +38,7 @@ data EventStore serialized m
   = EventStore
   { getLatestVersion :: UUID -> m EventVersion
     -- ^ Gets the latest 'EventVersion' for a given 'Projection'.
-  , getEvents :: UUID -> Maybe EventVersion -> m [StoredEvent serialized]
+  , getEvents :: UUID -> EventStoreQueryRange EventVersion -> m [StoredEvent serialized]
     -- ^ Retrieves all the events for a given 'Projection' using that
     -- projection's UUID. If an event version is provided then all events with
     -- a version greater than or equal to that version are returned.
@@ -50,7 +52,7 @@ data EventStore serialized m
 -- store.
 newtype GloballyOrderedEventStore serialized m =
   GloballyOrderedEventStore
-  { getSequencedEvents :: SequenceNumber -> m [GloballyOrderedEvent serialized]
+  { getSequencedEvents :: EventStoreQueryRange SequenceNumber -> m [GloballyOrderedEvent serialized]
   }
 
 -- | ExpectedVersion is used to assert the event stream is at a certain version

--- a/eventful-core/src/Eventful/Store/Queries.hs
+++ b/eventful-core/src/Eventful/Store/Queries.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE DeriveFunctor #-}
+
+module Eventful.Store.Queries
+  ( EventStoreQueryRange (..)
+  , EventStoreQueryStart (..)
+  , EventStoreQueryLimit (..)
+  , allEvents
+  , eventsUntil
+  , eventsStartingAt
+  , eventsStartingAtUntil
+  , eventsStartingAtTakeMax
+  ) where
+
+-- | This type defines how to query an event stream. It defines both where to
+-- start and where to stop in the stream.
+data EventStoreQueryRange a
+  = EventStoreQueryRange
+  { eventStoreQueryRangeStart :: EventStoreQueryStart a
+  , eventStoreQueryRangeLimit :: EventStoreQueryLimit a
+  } deriving (Functor)
+
+-- | This type defines where an event store query starts.
+data EventStoreQueryStart a
+  = StartFromBeginning
+  | StartQueryAt a
+  deriving (Show, Eq, Functor)
+
+-- | This type is used to limit the results of a query from an event store.
+data EventStoreQueryLimit a
+  = NoQueryLimit
+  | MaxNumberOfEvents Int
+  | StopQueryAt a
+  deriving (Show, Eq, Functor)
+
+allEvents :: EventStoreQueryRange a
+allEvents = EventStoreQueryRange StartFromBeginning NoQueryLimit
+
+eventsUntil :: a -> EventStoreQueryRange a
+eventsUntil end = EventStoreQueryRange StartFromBeginning (StopQueryAt end)
+
+eventsStartingAt :: a -> EventStoreQueryRange a
+eventsStartingAt start = EventStoreQueryRange (StartQueryAt start) NoQueryLimit
+
+eventsStartingAtUntil :: a -> a -> EventStoreQueryRange a
+eventsStartingAtUntil start end = EventStoreQueryRange (StartQueryAt start) (StopQueryAt end)
+
+eventsStartingAtTakeMax :: a -> Int -> EventStoreQueryRange a
+eventsStartingAtTakeMax start maxNum = EventStoreQueryRange (StartQueryAt start) (MaxNumberOfEvents maxNum)

--- a/eventful-core/src/Eventful/Store/Queries.hs
+++ b/eventful-core/src/Eventful/Store/Queries.hs
@@ -8,7 +8,7 @@ module Eventful.Store.Queries
   , eventsUntil
   , eventsStartingAt
   , eventsStartingAtUntil
-  , eventsStartingAtTakeMax
+  , eventsStartingAtTakeLimit
   ) where
 
 -- | This type defines how to query an event stream. It defines both where to
@@ -44,5 +44,5 @@ eventsStartingAt start = EventStoreQueryRange (StartQueryAt start) NoQueryLimit
 eventsStartingAtUntil :: a -> a -> EventStoreQueryRange a
 eventsStartingAtUntil start end = EventStoreQueryRange (StartQueryAt start) (StopQueryAt end)
 
-eventsStartingAtTakeMax :: a -> Int -> EventStoreQueryRange a
-eventsStartingAtTakeMax start maxNum = EventStoreQueryRange (StartQueryAt start) (MaxNumberOfEvents maxNum)
+eventsStartingAtTakeLimit :: a -> Int -> EventStoreQueryRange a
+eventsStartingAtTakeLimit start maxNum = EventStoreQueryRange (StartQueryAt start) (MaxNumberOfEvents maxNum)

--- a/eventful-test-helpers/src/Eventful/TestHelpers.hs
+++ b/eventful-test-helpers/src/Eventful/TestHelpers.hs
@@ -123,7 +123,7 @@ eventStoreSpec (EventStoreRunner withStore) = do
           getEvents store nil (eventsUntil 1) <*>
           getEvents store nil (eventsStartingAtUntil 1 2) <*>
           getEvents store nil (eventsStartingAt 2) <*>
-          getEvents store nil (eventsStartingAtTakeMax 0 2)
+          getEvents store nil (eventsStartingAtTakeLimit 0 2)
       (storedEventEvent <$> firstEvents) `shouldBe` take 2 sampleEvents
       (storedEventEvent <$> middleEvents) `shouldBe` take 2 (drop 1 sampleEvents)
       (storedEventEvent <$> laterEvents) `shouldBe` drop 2 sampleEvents
@@ -164,7 +164,7 @@ eventStoreSpec (EventStoreRunner withStore) = do
           getEvents store uuid1 (eventsUntil 1) <*>
           getEvents store uuid2 (eventsStartingAtUntil 1 2) <*>
           getEvents store uuid2 (eventsStartingAt 2) <*>
-          getEvents store uuid1 (eventsStartingAtTakeMax 1 1)
+          getEvents store uuid1 (eventsStartingAtTakeLimit 1 1)
       (storedEventEvent <$> firstEvents) `shouldBe` [Added 1, Added 4]
       (storedEventEvent <$> middleEvents) `shouldBe` [Added 3, Added 5]
       (storedEventEvent <$> laterEvents) `shouldBe` [Added 5]
@@ -240,7 +240,7 @@ sequencedEventStoreSpec (GloballyOrderedEventStoreRunner withStore) = do
           getSequencedEvents globalStore (eventsUntil 2) <*>
           getSequencedEvents globalStore (eventsStartingAtUntil 2 3) <*>
           getSequencedEvents globalStore (eventsStartingAt 3) <*>
-          getSequencedEvents globalStore (eventsStartingAtTakeMax 2 3)
+          getSequencedEvents globalStore (eventsStartingAtTakeLimit 2 3)
 
       (globallyOrderedEventEvent <$> firstEvents) `shouldBe` Added <$> [1..2]
       (globallyOrderedEventEvent <$> middleEvents) `shouldBe` Added <$> [2..3]

--- a/eventful-test-helpers/src/Eventful/TestHelpers.hs
+++ b/eventful-test-helpers/src/Eventful/TestHelpers.hs
@@ -100,36 +100,45 @@ eventStoreSpec (EventStoreRunner withStore) = do
 
   context "when a few events are inserted" $ do
     let
-      sampleEvents = [Added 1, Added 4, Added (-3)]
+      sampleEvents = [Added 1, Added 4, Added (-3), Added 5]
       withStore' action = withStore $ \store -> do
         _ <- storeEvents store NoStream nil sampleEvents
         action store
 
     it "should return events" $ do
-      events' <- withStore' $ \store ->
-        getEvents store nil Nothing
+      events' <- withStore' $ \store -> getEvents store nil allEvents
       (storedEventEvent <$> events') `shouldBe` sampleEvents
 
     it "should return correct event versions" $ do
-      (latestVersion, allEvents, someEvents) <- withStore' $ \store ->
-        (,,) <$>
+      (latestVersion, events) <- withStore' $ \store ->
+        (,) <$>
           getLatestVersion store nil <*>
-          getEvents store nil (Just (-1)) <*>
-          getEvents store nil (Just 1)
-      latestVersion `shouldBe` 2
-      (storedEventEvent <$> allEvents) `shouldBe` sampleEvents
-      (storedEventEvent <$> someEvents) `shouldBe` drop 1 sampleEvents
+          getEvents store nil allEvents
+      latestVersion `shouldBe` 3
+      (storedEventVersion <$> events) `shouldBe` [0, 1, 2, 3]
+
+    it "should return correct events with queries" $ do
+      (firstEvents, middleEvents, laterEvents, maxEvents) <- withStore' $ \store ->
+        (,,,) <$>
+          getEvents store nil (eventsUntil 1) <*>
+          getEvents store nil (eventsStartingAtUntil 1 2) <*>
+          getEvents store nil (eventsStartingAt 2) <*>
+          getEvents store nil (eventsStartingAtTakeMax 0 2)
+      (storedEventEvent <$> firstEvents) `shouldBe` take 2 sampleEvents
+      (storedEventEvent <$> middleEvents) `shouldBe` take 2 (drop 1 sampleEvents)
+      (storedEventEvent <$> laterEvents) `shouldBe` drop 2 sampleEvents
+      (storedEventEvent <$> maxEvents) `shouldBe` take 2 sampleEvents
 
     it "should return the latest projection" $ do
       projection <- withStore' $ \store ->
         getLatestProjection store counterProjection nil
-      projection `shouldBe` (Counter 2, 2)
+      projection `shouldBe` (Counter 7, 3)
 
   context "when events from multiple UUIDs are inserted" $ do
 
     it "should have the correct events for each aggregate" $ do
       (events1, events2) <- withStoreExampleEvents $ \store ->
-        (,) <$> getEvents store uuid1 Nothing <*> getEvents store uuid2 Nothing
+        (,) <$> getEvents store uuid1 allEvents <*> getEvents store uuid2 allEvents
       (storedEventEvent <$> events1) `shouldBe` Added <$> [1, 4]
       (storedEventEvent <$> events2) `shouldBe` Added <$> [2, 3, 5]
       (storedEventProjectionId <$> events1) `shouldBe` [uuid1, uuid1]
@@ -142,12 +151,24 @@ eventStoreSpec (EventStoreRunner withStore) = do
         (,,,) <$>
           getLatestVersion store uuid1 <*>
           getLatestVersion store uuid2 <*>
-          getEvents store uuid1 (Just 0) <*>
-          getEvents store uuid2 (Just 1)
+          getEvents store uuid1 allEvents <*>
+          getEvents store uuid2 allEvents
       latestVersion1 `shouldBe` 1
       latestVersion2 `shouldBe` 2
       storedEventEvent <$> events1 `shouldBe` [Added 1, Added 4]
-      storedEventEvent <$> events2 `shouldBe` [Added 3, Added 5]
+      storedEventEvent <$> events2 `shouldBe` [Added 2, Added 3, Added 5]
+
+    it "should return correct events with queries" $ do
+      (firstEvents, middleEvents, laterEvents, maxEvents) <- withStoreExampleEvents $ \store ->
+        (,,,) <$>
+          getEvents store uuid1 (eventsUntil 1) <*>
+          getEvents store uuid2 (eventsStartingAtUntil 1 2) <*>
+          getEvents store uuid2 (eventsStartingAt 2) <*>
+          getEvents store uuid1 (eventsStartingAtTakeMax 1 1)
+      (storedEventEvent <$> firstEvents) `shouldBe` [Added 1, Added 4]
+      (storedEventEvent <$> middleEvents) `shouldBe` [Added 3, Added 5]
+      (storedEventEvent <$> laterEvents) `shouldBe` [Added 5]
+      (storedEventEvent <$> maxEvents) `shouldBe` [Added 4]
 
     it "should produce the correct projections" $ do
       (proj1, proj2) <- withStoreExampleEvents $ \store ->
@@ -198,19 +219,33 @@ sequencedEventStoreSpec (GloballyOrderedEventStoreRunner withStore) = do
   context "when the event store is empty" $ do
 
     it "shouldn't have any events" $ do
-      events <- withStore (\_ globalStore -> getSequencedEvents globalStore 0)
+      events <- withStore (\_ globalStore -> getSequencedEvents globalStore allEvents)
       length events `shouldBe` 0
 
   context "when events from multiple UUIDs are inserted" $ do
 
     it "should have the correct events in global order" $ do
-      events' <- withStore $ \store globalStore -> do
+      events <- withStore $ \store globalStore -> do
         insertExampleEvents store
-        getSequencedEvents globalStore 0
-      (globallyOrderedEventEvent <$> events') `shouldBe` Added <$> [1..5]
-      (globallyOrderedEventProjectionId <$> events') `shouldBe` [uuid1, uuid2, uuid2, uuid1, uuid2]
-      (globallyOrderedEventVersion <$> events') `shouldBe` [0, 0, 1, 1, 2]
-      (globallyOrderedEventSequenceNumber <$> events') `shouldBe` [1..5]
+        getSequencedEvents globalStore allEvents
+      (globallyOrderedEventEvent <$> events) `shouldBe` Added <$> [1..5]
+      (globallyOrderedEventProjectionId <$> events) `shouldBe` [uuid1, uuid2, uuid2, uuid1, uuid2]
+      (globallyOrderedEventVersion <$> events) `shouldBe` [0, 0, 1, 1, 2]
+      (globallyOrderedEventSequenceNumber <$> events) `shouldBe` [1..5]
+
+    it "should handle queries" $ do
+      (firstEvents, middleEvents, laterEvents, maxEvents) <- withStore $ \store globalStore -> do
+        insertExampleEvents store
+        (,,,) <$>
+          getSequencedEvents globalStore (eventsUntil 2) <*>
+          getSequencedEvents globalStore (eventsStartingAtUntil 2 3) <*>
+          getSequencedEvents globalStore (eventsStartingAt 3) <*>
+          getSequencedEvents globalStore (eventsStartingAtTakeMax 2 3)
+
+      (globallyOrderedEventEvent <$> firstEvents) `shouldBe` Added <$> [1..2]
+      (globallyOrderedEventEvent <$> middleEvents) `shouldBe` Added <$> [2..3]
+      (globallyOrderedEventEvent <$> laterEvents) `shouldBe` Added <$> [3..5]
+      (globallyOrderedEventEvent <$> maxEvents) `shouldBe` Added <$> [2..4]
 
 insertExampleEvents
   :: (Monad m)

--- a/examples/bank/src/Bank/CLI/RunCommand.hs
+++ b/examples/bank/src/Bank/CLI/RunCommand.hs
@@ -24,9 +24,9 @@ runCLICommand pool (ViewAccountCLI uuid) = do
     getLatestProjection cliEventStore accountBankProjection uuid
   printJSONPretty state
 runCLICommand pool (ViewCustomerAccountsCLI name) = do
-  allEvents <- runDB pool $ getSequencedEvents cliGloballyOrderedEventStore 0
+  events <- runDB pool $ getSequencedEvents cliGloballyOrderedEventStore allEvents
   let
-    projectionEvents = globallyOrderedEventToProjectionEvent <$> allEvents
+    projectionEvents = globallyOrderedEventToProjectionEvent <$> events
     allCustomerAccounts = latestProjection customerAccountsProjection projectionEvents
     thisCustomerAccounts = getCustomerAccountsFromName allCustomerAccounts name
   case thisCustomerAccounts of


### PR DESCRIPTION
This PR adds an `EventStoreQueryRange` type to `getEvents` and `getSequencedEvents`. The main benefit of this is it allows users to chunk queries. Previously, you could start a stream at a given `EventVersion` or `SequenceNumber`, but then the `EventStore` would happily return all events after that. This is not very good for super large event streams.

For future work, I supposed there could be `eventful-pipes` and/or `eventful-conduit` to create pipes or conduits from these queries.