### PR TITLE
Add ProjectionCache for caching Projection state in event streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.1.3
 
+* Added `ProjectionCache` for caching `Projection` state in event streams.
 * Added `EventStoreQueryRange` to the APIs of the event store and the globally
   ordered event store. This allows the user to specify optional start and stop
   points for the query.

--- a/doc/tutorial/EventStore.lhs
+++ b/doc/tutorial/EventStore.lhs
@@ -107,7 +107,7 @@ import Counter
 counterStoreExample :: IO ()
 counterStoreExample = do
   -- First we need to create our in-memory event store.
-  (store :: EventStore CounterEvent STM, _) <- memoryEventStore
+  store :: EventStore CounterEvent STM <- tvarEventStore <$> eventMapTVar
 
   -- Lets store some events. Note that the 'atomically' functions is how we
   -- execute STM actions.

--- a/eventful-core/src/Eventful.hs
+++ b/eventful-core/src/Eventful.hs
@@ -5,6 +5,7 @@ module Eventful
 import Eventful.Aggregate as X
 import Eventful.EventBus as X
 import Eventful.Projection as X
+import Eventful.ProjectionCache.Types as X
 import Eventful.ProcessManager as X
 import Eventful.ReadModel.Class as X
 import Eventful.Serializer as X

--- a/eventful-core/src/Eventful/Projection.hs
+++ b/eventful-core/src/Eventful/Projection.hs
@@ -84,7 +84,7 @@ getLatestProjection
 getLatestProjection store projection@StreamProjection{..} = do
   events <- getEvents store streamProjectionUuid (eventsStartingAt $ streamProjectionVersion + 1)
   let
-    latestVersion = maxEventVersion events
+    latestVersion = newEventVersion events
     latestState = foldl' (projectionEventHandler streamProjectionProjection) streamProjectionState $ storedEventEvent <$> events
   return $
     projection
@@ -92,8 +92,8 @@ getLatestProjection store projection@StreamProjection{..} = do
     , streamProjectionState = latestState
     }
   where
-    maxEventVersion [] = -1
-    maxEventVersion es = maximum $ storedEventVersion <$> es
+    newEventVersion [] = streamProjectionVersion
+    newEventVersion es = maximum $ storedEventVersion <$> es
 
 -- | This is a combination of a 'Projection' and the latest projection state
 -- with respect to some 'SequenceNumber'. This is useful for in-memory read

--- a/eventful-core/src/Eventful/ProjectionCache/Types.hs
+++ b/eventful-core/src/Eventful/ProjectionCache/Types.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Eventful.ProjectionCache.Types
+  ( ProjectionCache (..)
+  , runProjectionCacheUsing
+  , serializedProjectionCache
+  , getLatestProjectionWithCache
+  , updateProjectionCache
+  ) where
+
+import Eventful.Projection
+import Eventful.Serializer
+import Eventful.Store.Class
+import Eventful.UUID
+
+-- | A 'ProjectionCache' caches snapshots of 'Projection's in event streams.
+-- This is useful if your event streams are very large. This cache operates on
+-- some 'Monad' @m@ and stores the 'Projection' state of type @serialized@.
+data ProjectionCache serialized m
+  = ProjectionCache
+  { storeProjection :: serialized -> EventVersion -> UUID -> m ()
+    -- ^ Stores the state for a projection at a given 'EventVersion'. This is
+    -- pretty unsafe, because there is no guarantee what is stored actually
+    -- corresponds to the events in the stream. Consider using
+    -- 'updateProjectionCache'.
+  , loadCachedProjection :: UUID -> m (Maybe (EventVersion, serialized))
+    -- ^ Loads latest projection state from the cache.
+  , clearOldProjections :: UUID -> m ()
+    -- ^ Clears all projections in the cache that are not the latest
+    -- projections.
+  }
+
+-- | Changes the monad an 'ProjectionCache' runs in. This is useful to run the
+-- cache in another 'Monad' while forgetting the original 'Monad'.
+runProjectionCacheUsing
+  :: (Monad m, Monad mstore)
+  => (forall a. mstore a -> m a)
+  -> ProjectionCache serialized mstore
+  -> ProjectionCache serialized m
+runProjectionCacheUsing runCache ProjectionCache{..} =
+  ProjectionCache
+  { storeProjection = \state version uuid -> runCache $ storeProjection state version uuid
+  , loadCachedProjection = runCache . loadCachedProjection
+  , clearOldProjections = runCache . clearOldProjections
+  }
+
+-- | Wraps a 'ProjectionCache' and transparently serializes/deserializes events for
+-- you. Note that in this implementation deserialization errors when using
+-- 'getEvents' are simply ignored (the event is not returned).
+serializedProjectionCache
+  :: (Monad m)
+  => Serializer state serialized
+  -> ProjectionCache serialized m
+  -> ProjectionCache state m
+serializedProjectionCache Serializer{..} ProjectionCache{..} =
+  ProjectionCache storeProjection' loadCachedProjection' clearOldProjections
+  where
+    storeProjection' state = storeProjection (serialize state)
+    loadCachedProjection' uuid = do
+      mState <- loadCachedProjection uuid
+      return $ mState >>= traverse deserialize
+
+-- | Like 'getLatestProjection', but uses a 'ProjectionCache' if it contains
+-- more recent state.
+getLatestProjectionWithCache
+  :: (Monad m)
+  => EventStore event m
+  -> ProjectionCache state m
+  -> StreamProjection state event
+  -> m (StreamProjection state event)
+getLatestProjectionWithCache store cache projection@StreamProjection{..} = do
+  mLatestState <- loadCachedProjection cache streamProjectionUuid
+  let
+    mkProjection' (version, state) =
+      if version > streamProjectionVersion
+      then projection { streamProjectionVersion = version, streamProjectionState = state }
+      else projection
+    projection' = maybe projection mkProjection' mLatestState
+  getLatestProjection store projection'
+
+-- | Loads the latest projection state from the cache/store and stores this
+-- value back into the projection cache.
+updateProjectionCache
+  :: (Monad m)
+  => EventStore event m
+  -> ProjectionCache state m
+  -> StreamProjection state event
+  -> m ()
+updateProjectionCache store cache projection = do
+  StreamProjection{..} <- getLatestProjectionWithCache store cache projection
+  storeProjection cache streamProjectionState streamProjectionVersion streamProjectionUuid

--- a/eventful-core/src/Eventful/ProjectionCache/Types.hs
+++ b/eventful-core/src/Eventful/ProjectionCache/Types.hs
@@ -74,14 +74,14 @@ getLatestProjectionWithCache
   -> ProjectionCache state m
   -> StreamProjection state event
   -> m (StreamProjection state event)
-getLatestProjectionWithCache store cache projection@StreamProjection{..} = do
-  mLatestState <- loadProjectionSnapshot cache streamProjectionUuid
+getLatestProjectionWithCache store cache originalProj = do
+  mLatestState <- loadProjectionSnapshot cache (streamProjectionUuid originalProj)
   let
     mkProjection' (version, state) =
-      if version > streamProjectionVersion
-      then projection { streamProjectionVersion = version, streamProjectionState = state }
-      else projection
-    projection' = maybe projection mkProjection' mLatestState
+      if version > streamProjectionVersion originalProj
+      then originalProj { streamProjectionVersion = version, streamProjectionState = state }
+      else originalProj
+    projection' = maybe originalProj mkProjection' mLatestState
   getLatestProjection store projection'
 
 -- | Loads the latest projection state from the cache/store and stores this

--- a/eventful-memory/src/Eventful/ProjectionCache/Memory.hs
+++ b/eventful-memory/src/Eventful/ProjectionCache/Memory.hs
@@ -37,7 +37,6 @@ tvarProjectionCache tvar =
   let
     storeProjectionSnapshot uuid version projState = modifyTVar' tvar (storeProjectionInMap uuid version projState)
     loadProjectionSnapshot uuid = Map.lookup uuid <$> readTVar tvar
-    clearSnapshots _ = pure ()
   in ProjectionCache{..}
 
 -- | A 'ProjectionCache' for some 'MonadState' that contains a 'ProjectionMap'.
@@ -50,7 +49,6 @@ embeddedStateProjectionCache getMap setMap =
   let
     storeProjectionSnapshot uuid version projState = modify' (storeProjectionSnapshot' uuid version projState)
     loadProjectionSnapshot uuid = Map.lookup uuid <$> gets getMap
-    clearSnapshots _ = pure ()
   in ProjectionCache{..}
   where
     storeProjectionSnapshot' uuid version projState state =

--- a/eventful-memory/src/Eventful/ProjectionCache/Memory.hs
+++ b/eventful-memory/src/Eventful/ProjectionCache/Memory.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Eventful.ProjectionCache.Memory
+  ( ProjectionMap
+  , embeddedStateProjectionCache
+  , module Eventful.ProjectionCache.Types
+  ) where
+
+import Control.Monad.State.Class hiding (state)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+
+import Eventful.ProjectionCache.Types
+import Eventful.Store.Class
+import Eventful.UUID
+
+-- | A 'ProjectionMap' just stores the latest snapshot for each UUID.
+type ProjectionMap serialized = Map UUID (EventVersion, serialized)
+
+storeProjectionInMap :: UUID -> EventVersion -> serialized -> ProjectionMap serialized -> ProjectionMap serialized
+storeProjectionInMap uuid version state = Map.insert uuid (version, state)
+
+-- | A 'ProjectionCache' for some 'MonadState' that contains a 'ProjectionMap'.
+embeddedStateProjectionCache
+  :: (MonadState s m)
+  => (s -> ProjectionMap serialized)
+  -> (s -> ProjectionMap serialized -> s)
+  -> ProjectionCache serialized m
+embeddedStateProjectionCache getMap setMap =
+  let
+    storeProjectionSnapshot uuid version projState = modify' (storeProjectionSnapshot' uuid version projState)
+    loadProjectionSnapshot uuid = Map.lookup uuid <$> gets getMap
+    clearSnapshots _ = pure ()
+  in ProjectionCache{..}
+  where
+    storeProjectionSnapshot' uuid version projState state =
+      setMap state $ storeProjectionInMap uuid version projState $ getMap state

--- a/eventful-memory/src/Eventful/ProjectionCache/Memory.hs
+++ b/eventful-memory/src/Eventful/ProjectionCache/Memory.hs
@@ -3,6 +3,7 @@
 
 module Eventful.ProjectionCache.Memory
   ( ProjectionMap
+  , emptyProjectionMap
   , embeddedStateProjectionCache
   , module Eventful.ProjectionCache.Types
   ) where
@@ -17,6 +18,9 @@ import Eventful.UUID
 
 -- | A 'ProjectionMap' just stores the latest snapshot for each UUID.
 type ProjectionMap serialized = Map UUID (EventVersion, serialized)
+
+emptyProjectionMap :: ProjectionMap serialized
+emptyProjectionMap = Map.empty
 
 storeProjectionInMap :: UUID -> EventVersion -> serialized -> ProjectionMap serialized -> ProjectionMap serialized
 storeProjectionInMap uuid version state = Map.insert uuid (version, state)

--- a/eventful-memory/tests/Eventful/ProjectionCache/MemorySpec.hs
+++ b/eventful-memory/tests/Eventful/ProjectionCache/MemorySpec.hs
@@ -1,5 +1,6 @@
 module Eventful.ProjectionCache.MemorySpec (spec) where
 
+import Control.Concurrent.STM
 import Control.Monad.State.Strict
 import Test.Hspec
 
@@ -11,8 +12,20 @@ import MemoryTestImport
 
 spec :: Spec
 spec = do
+  describe "TVar projection cache" $ do
+    projectionCacheSpec tvarProjectionCacheRunner
+
   describe "MonadState embedded memory projection cache" $ do
     projectionCacheSpec stateProjectionCacheRunner
+
+tvarProjectionCacheRunner :: ProjectionCacheRunner STM
+tvarProjectionCacheRunner = ProjectionCacheRunner $ \action -> do
+  eventTVar <- eventMapTVar
+  projTVar <- projectionMapTVar
+  let
+    store = tvarEventStore eventTVar
+    cache = tvarProjectionCache projTVar
+  atomically $ action store cache
 
 stateProjectionCacheRunner :: ProjectionCacheRunner (StateT (EmbeddedState Counter CounterEvent) IO)
 stateProjectionCacheRunner = ProjectionCacheRunner $ \action -> evalStateT (action store cache) emptyEmbeddedState

--- a/eventful-memory/tests/Eventful/ProjectionCache/MemorySpec.hs
+++ b/eventful-memory/tests/Eventful/ProjectionCache/MemorySpec.hs
@@ -1,0 +1,21 @@
+module Eventful.ProjectionCache.MemorySpec (spec) where
+
+import Control.Monad.State.Strict
+import Test.Hspec
+
+import Eventful.ProjectionCache.Memory
+import Eventful.Store.Memory
+import Eventful.TestHelpers
+
+import MemoryTestImport
+
+spec :: Spec
+spec = do
+  describe "MonadState embedded memory projection cache" $ do
+    projectionCacheSpec stateProjectionCacheRunner
+
+stateProjectionCacheRunner :: ProjectionCacheRunner (StateT (EmbeddedState Counter CounterEvent) IO)
+stateProjectionCacheRunner = ProjectionCacheRunner $ \action -> evalStateT (action store cache) emptyEmbeddedState
+  where
+    store = embeddedStateEventStore embeddedEventMap setEventMap
+    cache = embeddedStateProjectionCache embeddedProjectionMap setProjectionMap

--- a/eventful-memory/tests/Eventful/Store/MemorySpec.hs
+++ b/eventful-memory/tests/Eventful/Store/MemorySpec.hs
@@ -51,12 +51,12 @@ stateStoreGlobalRunner :: GloballyOrderedEventStoreRunner (StateT (EventMap Coun
 stateStoreGlobalRunner = GloballyOrderedEventStoreRunner $
   \action -> evalStateT (action stateEventStore stateGloballyOrderedEventStore) emptyEventMap
 
-embeddedStateStoreRunner :: EventStoreRunner (StateT (EmbeddedState Counter CounterEvent) IO)
+embeddedStateStoreRunner :: EventStoreRunner (StateT (StreamEmbeddedState Counter CounterEvent) IO)
 embeddedStateStoreRunner = EventStoreRunner $ \action -> evalStateT (action store) emptyEmbeddedState
   where
     store = embeddedStateEventStore embeddedEventMap setEventMap
 
-embeddedStateStoreGlobalRunner :: GloballyOrderedEventStoreRunner (StateT (EmbeddedState Counter CounterEvent) IO)
+embeddedStateStoreGlobalRunner :: GloballyOrderedEventStoreRunner (StateT (StreamEmbeddedState Counter CounterEvent) IO)
 embeddedStateStoreGlobalRunner = GloballyOrderedEventStoreRunner $
   \action -> evalStateT (action store globalStore) emptyEmbeddedState
   where

--- a/eventful-memory/tests/Eventful/Store/MemorySpec.hs
+++ b/eventful-memory/tests/Eventful/Store/MemorySpec.hs
@@ -28,10 +28,15 @@ spec = do
     sequencedEventStoreSpec embeddedStateStoreGlobalRunner
 
 tvarRunner :: EventStoreRunner STM
-tvarRunner = EventStoreRunner $ \action -> (fst <$> memoryEventStore) >>= atomically . action
+tvarRunner = EventStoreRunner $ \action -> (tvarEventStore <$> eventMapTVar) >>= atomically . action
 
 tvarGlobalRunner :: GloballyOrderedEventStoreRunner STM
-tvarGlobalRunner = GloballyOrderedEventStoreRunner $ \action -> memoryEventStore >>= atomically . uncurry action
+tvarGlobalRunner = GloballyOrderedEventStoreRunner $ \action -> do
+  tvar <- eventMapTVar
+  let
+    store = tvarEventStore tvar
+    globalStore = tvarGloballyOrderedEventStore tvar
+  atomically $ action store globalStore
 
 tvarDynamicRunner :: EventStoreRunner STM
 tvarDynamicRunner = EventStoreRunner $ \action -> (fst <$> makeDynamicTVarStore) >>= atomically . action

--- a/eventful-memory/tests/MemoryTestImport.hs
+++ b/eventful-memory/tests/MemoryTestImport.hs
@@ -15,8 +15,10 @@ import Eventful.TestHelpers
 
 makeDynamicTVarStore :: IO (EventStore CounterEvent STM, GloballyOrderedEventStore CounterEvent STM)
 makeDynamicTVarStore = do
-  (store, globalStore) <- memoryEventStore
+  tvar <- eventMapTVar
   let
+    store = tvarEventStore tvar
+    globalStore = tvarGloballyOrderedEventStore tvar
     store' = serializedEventStore dynamicSerializer store
     globalStore' = serializedGloballyOrderedEventStore dynamicSerializer globalStore
   return (store', globalStore')

--- a/eventful-memory/tests/MemoryTestImport.hs
+++ b/eventful-memory/tests/MemoryTestImport.hs
@@ -1,0 +1,38 @@
+module MemoryTestImport
+  ( makeDynamicTVarStore
+  , EmbeddedState (..)
+  , emptyEmbeddedState
+  , setEventMap
+  , setProjectionMap
+  ) where
+
+import Control.Concurrent.STM
+
+import Eventful.ProjectionCache.Memory
+import Eventful.Serializer
+import Eventful.Store.Memory
+import Eventful.TestHelpers
+
+makeDynamicTVarStore :: IO (EventStore CounterEvent STM, GloballyOrderedEventStore CounterEvent STM)
+makeDynamicTVarStore = do
+  (store, globalStore) <- memoryEventStore
+  let
+    store' = serializedEventStore dynamicSerializer store
+    globalStore' = serializedGloballyOrderedEventStore dynamicSerializer globalStore
+  return (store', globalStore')
+
+data EmbeddedState state event
+  = EmbeddedState
+  { _embeddedDummyArgument :: Int
+  , embeddedEventMap :: EventMap event
+  , embeddedProjectionMap :: ProjectionMap state
+  }
+
+emptyEmbeddedState :: EmbeddedState state event
+emptyEmbeddedState = EmbeddedState 100 emptyEventMap emptyProjectionMap
+
+setEventMap :: EmbeddedState state event -> EventMap event -> EmbeddedState state event
+setEventMap state' eventMap = state' { embeddedEventMap = eventMap }
+
+setProjectionMap :: EmbeddedState state event -> ProjectionMap state -> EmbeddedState state event
+setProjectionMap state' projectionMap = state' { embeddedProjectionMap = projectionMap }

--- a/eventful-test-helpers/package.yaml
+++ b/eventful-test-helpers/package.yaml
@@ -20,6 +20,7 @@ dependencies:
   - extra
   - hspec
   - monad-logger
+  - text
 
 library:
   source-dirs:

--- a/examples/counter-cli/counter-cli.hs
+++ b/examples/counter-cli/counter-cli.hs
@@ -15,7 +15,7 @@ import Eventful.Store.Memory
 main :: IO ()
 main = do
   -- Create the event store and run loop forever
-  (store, _) <- memoryEventStore
+  store <- tvarEventStore <$> eventMapTVar
   forever (readAndHandleCommand store)
 
 readAndHandleCommand :: EventStore CounterEvent STM -> IO ()


### PR DESCRIPTION
This should be a super useful addition to `eventful`. This will allow users to seamlessly load cached state instead of having to load entire event streams. I'm going to make backends for in-memory and SQL. I might also make a globally ordered version. I could make a backend for DynamoDB, but I don't use DynamoDB currently so I might not get around to it.