### PR TITLE
Deduplicate between stream queries and global queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.2.0
 
+* Breaking change: Made the API for `EventStore` and `GlobalStreamEventStore`
+  more similar so code can be more generic between them. This simplified a lot
+  of the event and projection types as well (now just variations on
+  `StreamEvent` and `StreamProjection`.
+
 ## 0.1.3
 
 * Added `ProjectionCache` for caching `Projection` state in event streams.

--- a/doc/tutorial/EventStore.lhs
+++ b/doc/tutorial/EventStore.lhs
@@ -121,27 +121,27 @@ counterStoreExample = do
   _ <- atomically $ storeEvents store AnyVersion uuid events
 
   -- Now read the events back and print
-  events' <- atomically $ getEvents store uuid allEvents
+  events' <- atomically $ getEvents store (allEvents uuid)
   print events'
 ```
 
 Output:
 
 ```
-[ StoredEvent
-  { storedEventProjectionId = 123e4567-e89b-12d3-a456-426655440000
-  , storedEventVersion = EventVersion {unEventVersion = 0}
-  , storedEventEvent = CounterIncremented 3
+[ StreamEvent
+  { streamEventProjectionId = 123e4567-e89b-12d3-a456-426655440000
+  , streamEventVersion = EventVersion {unEventVersion = 0}
+  , streamEventEvent = CounterIncremented 3
   }
-, StoredEvent
-  { storedEventProjectionId = 123e4567-e89b-12d3-a456-426655440000
-  , storedEventVersion = EventVersion {unEventVersion = 1}
-  , storedEventEvent = CounterDecremented 1
+, StreamEvent
+  { streamEventProjectionId = 123e4567-e89b-12d3-a456-426655440000
+  , streamEventVersion = EventVersion {unEventVersion = 1}
+  , streamEventEvent = CounterDecremented 1
   }
-, StoredEvent
-  { storedEventProjectionId = 123e4567-e89b-12d3-a456-426655440000
-  , storedEventVersion = EventVersion {unEventVersion = 2}
-  , storedEventEvent = CounterReset
+, StreamEvent
+  { streamEventProjectionId = 123e4567-e89b-12d3-a456-426655440000
+  , streamEventVersion = EventVersion {unEventVersion = 2}
+  , streamEventEvent = CounterReset
   }
 ]
 ```

--- a/eventful-core/src/Eventful/Aggregate.hs
+++ b/eventful-core/src/Eventful/Aggregate.hs
@@ -50,9 +50,9 @@ commandStoredAggregate
   -> command
   -> m [serialized]
 commandStoredAggregate store (Aggregate handler proj) uuid command = do
-  StreamProjection{..} <- getLatestProjection store (streamProjection proj uuid)
+  StreamProjection{..} <- getLatestProjection store (versionedStreamProjection uuid proj)
   let events = handler streamProjectionState command
-  mError <- storeEvents store (ExactVersion streamProjectionVersion) uuid events
+  mError <- storeEvents store (ExactVersion streamProjectionOrderKey) uuid events
   case mError of
     (Just err) -> error $ "TODO: Create aggregate restart logic. " ++ show err
     Nothing -> return events

--- a/eventful-core/src/Eventful/EventBus.hs
+++ b/eventful-core/src/Eventful/EventBus.hs
@@ -22,8 +22,7 @@ synchronousEventBusWrapper store handlers =
     handlers' = map ($ wrappedStore) handlers
     wrappedStore =
       EventStore
-      { getLatestVersion = getLatestVersion store
-      , getEvents = getEvents store
+      { getEvents = getEvents store
       , storeEvents = storeAndPublishEvents store handlers'
       }
   in wrappedStore

--- a/eventful-core/src/Eventful/ProcessManager.hs
+++ b/eventful-core/src/Eventful/ProcessManager.hs
@@ -21,7 +21,7 @@ import Eventful.UUID
 -- appropriate Aggregates or Projections in other streams.
 data ProcessManager state event command
   = ProcessManager
-  { processManagerProjection :: Projection state (StreamEvent UUID () event)
+  { processManagerProjection :: Projection state (VersionedStreamEvent event)
   , processManagerPendingCommands :: state -> [ProcessManagerCommand event command]
   , processManagerPendingEvents :: state -> [StreamEvent UUID () event]
   }

--- a/eventful-core/src/Eventful/ProcessManager.hs
+++ b/eventful-core/src/Eventful/ProcessManager.hs
@@ -21,9 +21,9 @@ import Eventful.UUID
 -- appropriate Aggregates or Projections in other streams.
 data ProcessManager state event command
   = ProcessManager
-  { processManagerProjection :: Projection state (ProjectionEvent event)
+  { processManagerProjection :: Projection state (StreamEvent UUID () event)
   , processManagerPendingCommands :: state -> [ProcessManagerCommand event command]
-  , processManagerPendingEvents :: state -> [ProjectionEvent event]
+  , processManagerPendingEvents :: state -> [StreamEvent UUID () event]
   }
 
 -- | This is a @command@ along with the UUID of the target 'Aggregate', and
@@ -52,5 +52,5 @@ applyProcessManagerCommandsAndEvents
 applyProcessManagerCommandsAndEvents ProcessManager{..} store state = do
   forM_ (processManagerPendingCommands state) $ \(ProcessManagerCommand aggregateId aggregate command) ->
     void $ commandStoredAggregate store aggregate aggregateId command
-  forM_ (processManagerPendingEvents state) $ \(ProjectionEvent projectionId event) ->
+  forM_ (processManagerPendingEvents state) $ \(StreamEvent projectionId () event) ->
     storeEvents store AnyVersion projectionId [event]

--- a/eventful-core/src/Eventful/ReadModel/Class.hs
+++ b/eventful-core/src/Eventful/ReadModel/Class.hs
@@ -16,7 +16,7 @@ data ReadModel model serialized m =
   ReadModel
   { readModelModel :: model
   , readModelLatestAppliedSequence :: model -> m SequenceNumber
-  , readModelHandleEvents :: model -> [GloballyOrderedEvent serialized] -> m ()
+  , readModelHandleEvents :: model -> [GlobalStreamEvent serialized] -> m ()
   }
 
 type PollingPeriodSeconds = Double
@@ -24,14 +24,14 @@ type PollingPeriodSeconds = Double
 runPollingReadModel
   :: (MonadIO m, Monad mstore)
   => ReadModel model serialized m
-  -> GloballyOrderedEventStore serialized mstore
+  -> GlobalStreamEventStore serialized mstore
   -> (forall a. mstore a -> m a)
   -> PollingPeriodSeconds
   -> m ()
-runPollingReadModel ReadModel{..} getGloballyOrderedEvents runStore waitSeconds = forever $ do
+runPollingReadModel ReadModel{..} globalStore runStore waitSeconds = forever $ do
   -- Get new events starting from latest applied sequence number
   latestSeq <- readModelLatestAppliedSequence readModelModel
-  newEvents <- runStore $ getSequencedEvents getGloballyOrderedEvents (eventsStartingAt $ latestSeq + 1)
+  newEvents <- runStore $ getGlobalEvents globalStore (eventsStartingAt () $ latestSeq + 1)
 
   -- Handle the new events
   readModelHandleEvents readModelModel newEvents

--- a/eventful-core/src/Eventful/Store/Queries.hs
+++ b/eventful-core/src/Eventful/Store/Queries.hs
@@ -1,48 +1,62 @@
+{-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Eventful.Store.Queries
-  ( EventStoreQueryRange (..)
-  , EventStoreQueryStart (..)
-  , EventStoreQueryLimit (..)
+  ( QueryRange (..)
+  , QueryStart (..)
+  , QueryLimit (..)
   , allEvents
   , eventsUntil
   , eventsStartingAt
   , eventsStartingAtUntil
   , eventsStartingAtTakeLimit
+  , StreamEvent (..)
   ) where
 
--- | This type defines how to query an event stream. It defines both where to
--- start and where to stop in the stream.
-data EventStoreQueryRange a
-  = EventStoreQueryRange
-  { eventStoreQueryRangeStart :: EventStoreQueryStart a
-  , eventStoreQueryRangeLimit :: EventStoreQueryLimit a
-  } deriving (Functor)
+-- | This type defines how to query an event stream. It defines the stream key
+-- and the start/stop points for the query.
+data QueryRange key orderKey
+  = QueryRange
+  { queryRangeKey :: key
+  , queryRangeStart :: QueryStart orderKey
+  , queryRangeLimit :: QueryLimit orderKey
+  } deriving (Show, Eq)
 
 -- | This type defines where an event store query starts.
-data EventStoreQueryStart a
+data QueryStart orderKey
   = StartFromBeginning
-  | StartQueryAt a
+  | StartQueryAt orderKey
   deriving (Show, Eq, Functor)
 
 -- | This type is used to limit the results of a query from an event store.
-data EventStoreQueryLimit a
+data QueryLimit orderKey
   = NoQueryLimit
   | MaxNumberOfEvents Int
-  | StopQueryAt a
+  | StopQueryAt orderKey
   deriving (Show, Eq, Functor)
 
-allEvents :: EventStoreQueryRange a
-allEvents = EventStoreQueryRange StartFromBeginning NoQueryLimit
+allEvents :: key -> QueryRange key orderKey
+allEvents key = QueryRange key StartFromBeginning NoQueryLimit
 
-eventsUntil :: a -> EventStoreQueryRange a
-eventsUntil end = EventStoreQueryRange StartFromBeginning (StopQueryAt end)
+eventsUntil :: key -> orderKey -> QueryRange key orderKey
+eventsUntil key end = QueryRange key StartFromBeginning (StopQueryAt end)
 
-eventsStartingAt :: a -> EventStoreQueryRange a
-eventsStartingAt start = EventStoreQueryRange (StartQueryAt start) NoQueryLimit
+eventsStartingAt :: key -> orderKey -> QueryRange key orderKey
+eventsStartingAt key start = QueryRange key (StartQueryAt start) NoQueryLimit
 
-eventsStartingAtUntil :: a -> a -> EventStoreQueryRange a
-eventsStartingAtUntil start end = EventStoreQueryRange (StartQueryAt start) (StopQueryAt end)
+eventsStartingAtUntil :: key -> orderKey -> orderKey -> QueryRange key orderKey
+eventsStartingAtUntil key start end = QueryRange key (StartQueryAt start) (StopQueryAt end)
 
-eventsStartingAtTakeLimit :: a -> Int -> EventStoreQueryRange a
-eventsStartingAtTakeLimit start maxNum = EventStoreQueryRange (StartQueryAt start) (MaxNumberOfEvents maxNum)
+eventsStartingAtTakeLimit :: key -> orderKey -> Int -> QueryRange key orderKey
+eventsStartingAtTakeLimit key start maxNum = QueryRange key (StartQueryAt start) (MaxNumberOfEvents maxNum)
+
+-- | An event along with the keys from the particular event stream it was
+-- queried from.
+data StreamEvent key orderKey event
+  = StreamEvent
+  { streamEventKey :: !key
+  , streamEventOrderKey :: !orderKey
+  , streamEventEvent :: !event
+  } deriving (Show, Eq, Functor, Foldable, Traversable)

--- a/eventful-memory/src/Eventful/ReadModel/Memory.hs
+++ b/eventful-memory/src/Eventful/ReadModel/Memory.hs
@@ -20,7 +20,7 @@ data MemoryReadModelData modeldata
 memoryReadModel
   :: (MonadIO m)
   => modeldata
-  -> (modeldata -> [GloballyOrderedEvent serialized] -> m modeldata)
+  -> (modeldata -> [GlobalStreamEvent serialized] -> m modeldata)
   -> IO (ReadModel (TVar (MemoryReadModelData modeldata)) serialized m)
 memoryReadModel initialValue handleEvents = do
   tvar <- newTVarIO $ MemoryReadModelData (-1) initialValue
@@ -29,6 +29,6 @@ memoryReadModel initialValue handleEvents = do
     getLatestSequence tvar' = liftIO $ memoryReadModelDataLatestSequenceNumber <$> readTVarIO tvar'
     handleTVarEvents tvar' events = do
       (MemoryReadModelData latestSeq modelData) <- liftIO $ readTVarIO tvar'
-      let latestSeq' = maximumDef latestSeq (globallyOrderedEventSequenceNumber <$> events)
+      let latestSeq' = maximumDef latestSeq (streamEventOrderKey <$> events)
       modelData' <- handleEvents modelData events
       liftIO . atomically . writeTVar tvar' $ MemoryReadModelData latestSeq' modelData'

--- a/eventful-memory/src/Eventful/Store/Memory.hs
+++ b/eventful-memory/src/Eventful/Store/Memory.hs
@@ -151,7 +151,7 @@ storeEventMap
 storeEventMap store@(EventMap uuidMap seqNum) uuid events =
   let
     versStart = latestEventVersion store uuid + 1
-    storedEvents = zipWith3 (\seqNum' vers event -> StreamEvent () seqNum' (StreamEvent uuid vers event)) [seqNum + 1..] [versStart..] events
-    newMap = Map.insertWith (flip (><)) uuid (Seq.fromList storedEvents) uuidMap
+    streamEvents = zipWith3 (\seqNum' vers event -> StreamEvent () seqNum' (StreamEvent uuid vers event)) [seqNum + 1..] [versStart..] events
+    newMap = Map.insertWith (flip (><)) uuid (Seq.fromList streamEvents) uuidMap
     newSeq = seqNum + (SequenceNumber $ length events)
   in EventMap newMap newSeq

--- a/eventful-memory/src/Eventful/Store/Memory.hs
+++ b/eventful-memory/src/Eventful/Store/Memory.hs
@@ -3,11 +3,11 @@
 
 module Eventful.Store.Memory
   ( tvarEventStore
-  , tvarGloballyOrderedEventStore
+  , tvarGlobalStreamEventStore
   , stateEventStore
-  , stateGloballyOrderedEventStore
+  , stateGlobalStreamEventStore
   , embeddedStateEventStore
-  , embeddedStateGloballyOrderedEventStore
+  , embeddedStateGlobalStreamEventStore
   , EventMap
   , emptyEventMap
   , eventMapTVar
@@ -30,7 +30,7 @@ import Eventful.UUID
 -- | Internal data structure used for the in-memory event stores.
 data EventMap serialized
   = EventMap
-  { _eventMapUuidMap :: Map UUID (Seq (GloballyOrderedEvent serialized))
+  { _eventMapUuidMap :: Map UUID (Seq (GlobalStreamEvent serialized))
   , _eventMapSeqNum :: SequenceNumber
   -- TODO: Add projection cache here
   }
@@ -51,17 +51,17 @@ tvarEventStore :: TVar (EventMap serialized) -> EventStore serialized STM
 tvarEventStore tvar =
   let
     getLatestVersion uuid = flip latestEventVersion uuid <$> readTVar tvar
-    getEvents uuid range = (\s -> lookupEventsInRange s uuid range) <$> readTVar tvar
+    getEvents range = lookupEventsInRange range <$> readTVar tvar
     storeEvents' uuid events = modifyTVar' tvar (\store -> storeEventMap store uuid events)
     storeEvents = transactionalExpectedWriteHelper getLatestVersion storeEvents'
   in EventStore{..}
 
--- | Analog of 'tvarEventStore' for a 'GloballyOrderedEventStore'
-tvarGloballyOrderedEventStore :: TVar (EventMap serialized) -> GloballyOrderedEventStore serialized STM
-tvarGloballyOrderedEventStore tvar =
+-- | Analog of 'tvarEventStore' for a 'GlobalStreamEventStore'
+tvarGlobalStreamEventStore :: TVar (EventMap serialized) -> GlobalStreamEventStore serialized STM
+tvarGlobalStreamEventStore tvar =
   let
-    getSequencedEvents range = flip lookupEventMapRange range <$> readTVar tvar
-  in GloballyOrderedEventStore{..}
+    getGlobalEvents range = flip lookupEventMapRange range <$> readTVar tvar
+  in GlobalStreamEventStore{..}
 
 -- | Specialized version of 'embeddedStateEventStore' that only contains an
 -- 'EventMap' in the state.
@@ -81,7 +81,7 @@ embeddedStateEventStore
 embeddedStateEventStore getMap setMap =
   let
     getLatestVersion uuid = flip latestEventVersion uuid <$> gets getMap
-    getEvents uuid range = (\s -> lookupEventsInRange s uuid range) <$> gets getMap
+    getEvents range = lookupEventsInRange range <$> gets getMap
     storeEvents' uuid events = modify' (modifyStore uuid events)
     storeEvents = transactionalExpectedWriteHelper getLatestVersion storeEvents'
   in EventStore{..}
@@ -92,41 +92,42 @@ embeddedStateEventStore getMap setMap =
         store' = storeEventMap store uuid events
       in setMap state' store'
 
--- | Analogous to 'stateEventStore' for a 'GloballyOrderedEventStore'.
-stateGloballyOrderedEventStore
+-- | Analogous to 'stateEventStore' for a 'GlobalStreamEventStore'.
+stateGlobalStreamEventStore
   :: (MonadState (EventMap serialized) m)
-  => GloballyOrderedEventStore serialized m
-stateGloballyOrderedEventStore = embeddedStateGloballyOrderedEventStore id
+  => GlobalStreamEventStore serialized m
+stateGlobalStreamEventStore = embeddedStateGlobalStreamEventStore id
 
--- | Analogous to 'embeddedStateEventStore' for a 'GloballyOrderedEventStore'.
-embeddedStateGloballyOrderedEventStore
+-- | Analogous to 'embeddedStateEventStore' for a 'GlobalStreamEventStore'.
+embeddedStateGlobalStreamEventStore
   :: (MonadState s m)
   => (s -> EventMap serialized)
-  -> GloballyOrderedEventStore serialized m
-embeddedStateGloballyOrderedEventStore getMap =
+  -> GlobalStreamEventStore serialized m
+embeddedStateGlobalStreamEventStore getMap =
   let
-    getSequencedEvents range = flip lookupEventMapRange range <$> gets getMap
-  in GloballyOrderedEventStore{..}
+    getGlobalEvents range = flip lookupEventMapRange range <$> gets getMap
+  in GlobalStreamEventStore{..}
 
-lookupEventMapRaw :: EventMap serialized -> UUID -> Seq (StoredEvent serialized)
+lookupEventMapRaw :: EventMap serialized -> UUID -> Seq (VersionedStreamEvent serialized)
 lookupEventMapRaw (EventMap uuidMap _) uuid =
-  fmap globallyOrderedEventToStoredEvent $ fromMaybe Seq.empty $ Map.lookup uuid uuidMap
+  fmap streamEventEvent $ fromMaybe Seq.empty $ Map.lookup uuid uuidMap
 
-lookupEventsInRange :: EventMap serialized -> UUID -> EventStoreQueryRange EventVersion -> [StoredEvent serialized]
-lookupEventsInRange store uuid range = filterEventsByRange range' 0 rawEvents
+lookupEventsInRange :: QueryRange UUID EventVersion -> EventMap serialized -> [VersionedStreamEvent serialized]
+lookupEventsInRange (QueryRange uuid start limit) store = filterEventsByRange start' limit' 0 rawEvents
   where
-    range' = unEventVersion <$> range
+    start' = unEventVersion <$> start
+    limit' = unEventVersion <$> limit
     rawEvents = toList $ lookupEventMapRaw store uuid
 
-filterEventsByRange :: EventStoreQueryRange Int -> Int -> [event] -> [event]
-filterEventsByRange EventStoreQueryRange{..} defaultStart events =
+filterEventsByRange :: QueryStart Int -> QueryLimit Int -> Int -> [event] -> [event]
+filterEventsByRange queryStart queryLimit defaultStart events =
   let
     (start', events') =
-      case eventStoreQueryRangeStart of
+      case queryStart of
         StartFromBeginning -> (defaultStart, events)
         StartQueryAt start -> (start, drop (start - defaultStart) events)
     events'' =
-      case eventStoreQueryRangeLimit of
+      case queryLimit of
         NoQueryLimit -> events'
         MaxNumberOfEvents num -> take num events'
         StopQueryAt stop -> take (stop - start' + 1) events'
@@ -135,12 +136,13 @@ filterEventsByRange EventStoreQueryRange{..} defaultStart events =
 latestEventVersion :: EventMap serialized -> UUID -> EventVersion
 latestEventVersion store uuid = EventVersion $ Seq.length (lookupEventMapRaw store uuid) - 1
 
-lookupEventMapRange :: EventMap serialized -> EventStoreQueryRange SequenceNumber -> [GloballyOrderedEvent serialized]
-lookupEventMapRange (EventMap uuidMap _) range = filterEventsByRange range' 1 rawEvents
+lookupEventMapRange :: EventMap serialized -> QueryRange () SequenceNumber -> [GlobalStreamEvent serialized]
+lookupEventMapRange (EventMap uuidMap _) (QueryRange () start limit) = filterEventsByRange start' limit' 1 rawEvents
   where
-    range' = unSequenceNumber <$> range
+    start' = unSequenceNumber <$> start
+    limit' = unSequenceNumber <$> limit
     rawEvents =
-      sortOn globallyOrderedEventSequenceNumber $
+      sortOn streamEventOrderKey $
       concat $
       toList <$> toList uuidMap
 
@@ -149,7 +151,7 @@ storeEventMap
 storeEventMap store@(EventMap uuidMap seqNum) uuid events =
   let
     versStart = latestEventVersion store uuid + 1
-    storedEvents = zipWith storedEventToGloballyOrderedEvent [seqNum + 1..] $ zipWith (StoredEvent uuid) [versStart..] events
+    storedEvents = zipWith3 (\seqNum' vers event -> StreamEvent () seqNum' (StreamEvent uuid vers event)) [seqNum + 1..] [versStart..] events
     newMap = Map.insertWith (flip (><)) uuid (Seq.fromList storedEvents) uuidMap
     newSeq = seqNum + (SequenceNumber $ length events)
   in EventMap newMap newSeq

--- a/eventful-memory/tests/Eventful/ProjectionCache/MemorySpec.hs
+++ b/eventful-memory/tests/Eventful/ProjectionCache/MemorySpec.hs
@@ -13,15 +13,15 @@ import MemoryTestImport
 spec :: Spec
 spec = do
   describe "TVar projection cache" $ do
-    streamProjectionCacheSpec tvarStreamProjectionCacheRunner
-    globallyOrderedProjectionCacheSpec tvarGloballyOrderedProjectionCacheRunner
+    versionedProjectionCacheSpec tvarVersionedProjectionCacheRunner
+    globalStreamProjectionCacheSpec tvarGlobalStreamProjectionCacheRunner
 
   describe "MonadState embedded memory projection cache" $ do
-    streamProjectionCacheSpec stateStreamProjectionCacheRunner
-    globallyOrderedProjectionCacheSpec stateGloballyOrderedProjectionCacheRunner
+    versionedProjectionCacheSpec stateVersionedProjectionCacheRunner
+    globalStreamProjectionCacheSpec stateGlobalStreamProjectionCacheRunner
 
-tvarStreamProjectionCacheRunner :: StreamProjectionCacheRunner STM
-tvarStreamProjectionCacheRunner = StreamProjectionCacheRunner $ \action -> do
+tvarVersionedProjectionCacheRunner :: VersionedProjectionCacheRunner STM
+tvarVersionedProjectionCacheRunner = VersionedProjectionCacheRunner $ \action -> do
   eventTVar <- eventMapTVar
   projTVar <- projectionMapTVar
   let
@@ -29,26 +29,26 @@ tvarStreamProjectionCacheRunner = StreamProjectionCacheRunner $ \action -> do
     cache = tvarProjectionCache projTVar
   atomically $ action store cache
 
-tvarGloballyOrderedProjectionCacheRunner :: GloballyOrderedProjectionCacheRunner STM
-tvarGloballyOrderedProjectionCacheRunner = GloballyOrderedProjectionCacheRunner $ \action -> do
+tvarGlobalStreamProjectionCacheRunner :: GlobalStreamProjectionCacheRunner STM
+tvarGlobalStreamProjectionCacheRunner = GlobalStreamProjectionCacheRunner $ \action -> do
   eventTVar <- eventMapTVar
   projTVar <- projectionMapTVar
   let
     store = tvarEventStore eventTVar
-    globalStore = tvarGloballyOrderedEventStore eventTVar
+    globalStore = tvarGlobalStreamEventStore eventTVar
     cache = tvarProjectionCache projTVar
   atomically $ action store globalStore cache
 
-stateStreamProjectionCacheRunner :: StreamProjectionCacheRunner (StateT (StreamEmbeddedState Counter CounterEvent) IO)
-stateStreamProjectionCacheRunner = StreamProjectionCacheRunner $ \action -> evalStateT (action store cache) emptyEmbeddedState
+stateVersionedProjectionCacheRunner :: VersionedProjectionCacheRunner (StateT (StreamEmbeddedState Counter CounterEvent) IO)
+stateVersionedProjectionCacheRunner = VersionedProjectionCacheRunner $ \action -> evalStateT (action store cache) emptyEmbeddedState
   where
     store = embeddedStateEventStore embeddedEventMap setEventMap
     cache = embeddedStateProjectionCache embeddedProjectionMap setProjectionMap
 
-stateGloballyOrderedProjectionCacheRunner :: GloballyOrderedProjectionCacheRunner (StateT (GloballyOrderedEmbeddedState Counter CounterEvent Text) IO)
-stateGloballyOrderedProjectionCacheRunner =
-  GloballyOrderedProjectionCacheRunner $ \action -> evalStateT (action store globalStore cache) emptyEmbeddedState
+stateGlobalStreamProjectionCacheRunner :: GlobalStreamProjectionCacheRunner (StateT (GlobalStreamEmbeddedState Counter CounterEvent Text) IO)
+stateGlobalStreamProjectionCacheRunner =
+  GlobalStreamProjectionCacheRunner $ \action -> evalStateT (action store globalStore cache) emptyEmbeddedState
   where
     store = embeddedStateEventStore embeddedEventMap setEventMap
-    globalStore = embeddedStateGloballyOrderedEventStore embeddedEventMap
+    globalStore = embeddedStateGlobalStreamEventStore embeddedEventMap
     cache = embeddedStateProjectionCache embeddedProjectionMap setProjectionMap

--- a/eventful-memory/tests/Eventful/Store/MemorySpec.hs
+++ b/eventful-memory/tests/Eventful/Store/MemorySpec.hs
@@ -13,52 +13,52 @@ spec :: Spec
 spec = do
   describe "TVar memory event store with actual event type" $ do
     eventStoreSpec tvarRunner
-    sequencedEventStoreSpec tvarGlobalRunner
+    globalStreamEventStoreSpec tvarGlobalRunner
 
   describe "TVar memory event store with Dynamic serialized type" $ do
     eventStoreSpec tvarDynamicRunner
-    sequencedEventStoreSpec tvarDynamicGlobalRunner
+    globalStreamEventStoreSpec tvarDynamicGlobalRunner
 
   describe "MonadState memory event store with actual event type" $ do
     eventStoreSpec stateStoreRunner
-    sequencedEventStoreSpec stateStoreGlobalRunner
+    globalStreamEventStoreSpec stateStoreGlobalRunner
 
   describe "MonadState embedded memory event store with actual event type" $ do
     eventStoreSpec embeddedStateStoreRunner
-    sequencedEventStoreSpec embeddedStateStoreGlobalRunner
+    globalStreamEventStoreSpec embeddedStateStoreGlobalRunner
 
 tvarRunner :: EventStoreRunner STM
 tvarRunner = EventStoreRunner $ \action -> (tvarEventStore <$> eventMapTVar) >>= atomically . action
 
-tvarGlobalRunner :: GloballyOrderedEventStoreRunner STM
-tvarGlobalRunner = GloballyOrderedEventStoreRunner $ \action -> do
+tvarGlobalRunner :: GlobalStreamEventStoreRunner STM
+tvarGlobalRunner = GlobalStreamEventStoreRunner $ \action -> do
   tvar <- eventMapTVar
   let
     store = tvarEventStore tvar
-    globalStore = tvarGloballyOrderedEventStore tvar
+    globalStore = tvarGlobalStreamEventStore tvar
   atomically $ action store globalStore
 
 tvarDynamicRunner :: EventStoreRunner STM
 tvarDynamicRunner = EventStoreRunner $ \action -> (fst <$> makeDynamicTVarStore) >>= atomically . action
 
-tvarDynamicGlobalRunner :: GloballyOrderedEventStoreRunner STM
-tvarDynamicGlobalRunner = GloballyOrderedEventStoreRunner $ \action -> makeDynamicTVarStore >>= atomically . uncurry action
+tvarDynamicGlobalRunner :: GlobalStreamEventStoreRunner STM
+tvarDynamicGlobalRunner = GlobalStreamEventStoreRunner $ \action -> makeDynamicTVarStore >>= atomically . uncurry action
 
 stateStoreRunner :: EventStoreRunner (StateT (EventMap CounterEvent) IO)
 stateStoreRunner = EventStoreRunner $ \action -> evalStateT (action stateEventStore) emptyEventMap
 
-stateStoreGlobalRunner :: GloballyOrderedEventStoreRunner (StateT (EventMap CounterEvent) IO)
-stateStoreGlobalRunner = GloballyOrderedEventStoreRunner $
-  \action -> evalStateT (action stateEventStore stateGloballyOrderedEventStore) emptyEventMap
+stateStoreGlobalRunner :: GlobalStreamEventStoreRunner (StateT (EventMap CounterEvent) IO)
+stateStoreGlobalRunner = GlobalStreamEventStoreRunner $
+  \action -> evalStateT (action stateEventStore stateGlobalStreamEventStore) emptyEventMap
 
 embeddedStateStoreRunner :: EventStoreRunner (StateT (StreamEmbeddedState Counter CounterEvent) IO)
 embeddedStateStoreRunner = EventStoreRunner $ \action -> evalStateT (action store) emptyEmbeddedState
   where
     store = embeddedStateEventStore embeddedEventMap setEventMap
 
-embeddedStateStoreGlobalRunner :: GloballyOrderedEventStoreRunner (StateT (StreamEmbeddedState Counter CounterEvent) IO)
-embeddedStateStoreGlobalRunner = GloballyOrderedEventStoreRunner $
+embeddedStateStoreGlobalRunner :: GlobalStreamEventStoreRunner (StateT (StreamEmbeddedState Counter CounterEvent) IO)
+embeddedStateStoreGlobalRunner = GlobalStreamEventStoreRunner $
   \action -> evalStateT (action store globalStore) emptyEmbeddedState
   where
     store = embeddedStateEventStore embeddedEventMap setEventMap
-    globalStore = embeddedStateGloballyOrderedEventStore embeddedEventMap
+    globalStore = embeddedStateGlobalStreamEventStore embeddedEventMap

--- a/eventful-memory/tests/MemoryTestImport.hs
+++ b/eventful-memory/tests/MemoryTestImport.hs
@@ -2,7 +2,7 @@ module MemoryTestImport
   ( makeDynamicTVarStore
   , EmbeddedState (..)
   , StreamEmbeddedState
-  , GloballyOrderedEmbeddedState
+  , GlobalStreamEmbeddedState
   , emptyEmbeddedState
   , setEventMap
   , setProjectionMap
@@ -16,14 +16,14 @@ import Eventful.Store.Memory
 import Eventful.TestHelpers
 import Eventful.UUID
 
-makeDynamicTVarStore :: IO (EventStore CounterEvent STM, GloballyOrderedEventStore CounterEvent STM)
+makeDynamicTVarStore :: IO (EventStore CounterEvent STM, GlobalStreamEventStore CounterEvent STM)
 makeDynamicTVarStore = do
   tvar <- eventMapTVar
   let
     store = tvarEventStore tvar
-    globalStore = tvarGloballyOrderedEventStore tvar
+    globalStore = tvarGlobalStreamEventStore tvar
     store' = serializedEventStore dynamicSerializer store
-    globalStore' = serializedGloballyOrderedEventStore dynamicSerializer globalStore
+    globalStore' = serializedGlobalStreamEventStore dynamicSerializer globalStore
   return (store', globalStore')
 
 data EmbeddedState state event key orderKey
@@ -34,7 +34,7 @@ data EmbeddedState state event key orderKey
   }
 
 type StreamEmbeddedState state event = EmbeddedState state event UUID EventVersion
-type GloballyOrderedEmbeddedState state event key = EmbeddedState state event key SequenceNumber
+type GlobalStreamEmbeddedState state event key = EmbeddedState state event key SequenceNumber
 
 emptyEmbeddedState :: EmbeddedState state event key orderKey
 emptyEmbeddedState = EmbeddedState 100 emptyEventMap emptyProjectionMap

--- a/eventful-postgresql/tests/Eventful/Store/PostgresqlSpec.hs
+++ b/eventful-postgresql/tests/Eventful/Store/PostgresqlSpec.hs
@@ -15,7 +15,7 @@ spec :: Spec
 spec = do
   describe "Postgres event store" $ do
     eventStoreSpec postgresStoreRunner
-    sequencedEventStoreSpec postgresStoreGlobalRunner
+    globalStreamEventStoreSpec postgresStoreGlobalRunner
 
 makeStore :: (MonadIO m) => m (EventStore CounterEvent (SqlPersistT m), ConnectionPool)
 makeStore = do
@@ -52,8 +52,8 @@ postgresStoreRunner = EventStoreRunner $ \action -> do
   (store, pool) <- makeStore
   runSqlPool (action store) pool
 
-postgresStoreGlobalRunner :: GloballyOrderedEventStoreRunner (SqlPersistT IO)
-postgresStoreGlobalRunner = GloballyOrderedEventStoreRunner $ \action -> do
+postgresStoreGlobalRunner :: GlobalStreamEventStoreRunner (SqlPersistT IO)
+postgresStoreGlobalRunner = GlobalStreamEventStoreRunner $ \action -> do
   (store, pool) <- makeStore
-  let globalStore = serializedGloballyOrderedEventStore jsonStringSerializer (sqlGloballyOrderedEventStore defaultSqlEventStoreConfig)
+  let globalStore = serializedGlobalStreamEventStore jsonStringSerializer (sqlGlobalStreamEventStore defaultSqlEventStoreConfig)
   runSqlPool (action store globalStore) pool

--- a/eventful-sqlite/tests/Eventful/Store/SqliteSpec.hs
+++ b/eventful-sqlite/tests/Eventful/Store/SqliteSpec.hs
@@ -12,13 +12,13 @@ spec :: Spec
 spec = do
   describe "Sqlite event store" $ do
     eventStoreSpec sqliteStoreRunner
-    sequencedEventStoreSpec sqliteStoreGlobalRunner
+    globalStreamEventStoreSpec sqliteStoreGlobalRunner
 
   -- This is really a test for runEventStoreUsing and
-  -- runGloballyOrderedEventStoreUsing. This is just a good place to put it.
-  describe "runEventStoreUsing and runGloballyOrderedEventStoreUsing for the sqlite store" $ do
+  -- runGlobalStreamEventStoreUsing. This is just a good place to put it.
+  describe "runEventStoreUsing and runGlobalStreamEventStoreUsing for the sqlite store" $ do
     eventStoreSpec sqliteIOStoreRunner
-    sequencedEventStoreSpec sqliteIOStoreGlobalRunner
+    globalStreamEventStoreSpec sqliteIOStoreGlobalRunner
 
 makeStore :: IO (EventStore CounterEvent (SqlPersistT IO), ConnectionPool)
 makeStore = do
@@ -32,10 +32,10 @@ sqliteStoreRunner = EventStoreRunner $ \action -> do
   (store, pool) <- makeStore
   runSqlPool (action store) pool
 
-sqliteStoreGlobalRunner :: GloballyOrderedEventStoreRunner (SqlPersistT IO)
-sqliteStoreGlobalRunner = GloballyOrderedEventStoreRunner $ \action -> do
+sqliteStoreGlobalRunner :: GlobalStreamEventStoreRunner (SqlPersistT IO)
+sqliteStoreGlobalRunner = GlobalStreamEventStoreRunner $ \action -> do
   (store, pool) <- makeStore
-  let globalStore = serializedGloballyOrderedEventStore jsonStringSerializer (sqlGloballyOrderedEventStore defaultSqlEventStoreConfig)
+  let globalStore = serializedGlobalStreamEventStore jsonStringSerializer (sqlGlobalStreamEventStore defaultSqlEventStoreConfig)
   runSqlPool (action store globalStore) pool
 
 makeIOStore :: IO (EventStore CounterEvent IO, ConnectionPool)
@@ -49,10 +49,10 @@ sqliteIOStoreRunner = EventStoreRunner $ \action -> do
   (store, _) <- makeIOStore
   action store
 
-sqliteIOStoreGlobalRunner :: GloballyOrderedEventStoreRunner IO
-sqliteIOStoreGlobalRunner = GloballyOrderedEventStoreRunner $ \action -> do
+sqliteIOStoreGlobalRunner :: GlobalStreamEventStoreRunner IO
+sqliteIOStoreGlobalRunner = GlobalStreamEventStoreRunner $ \action -> do
   (store, pool) <- makeIOStore
   let
-    globalStore = serializedGloballyOrderedEventStore jsonStringSerializer (sqlGloballyOrderedEventStore defaultSqlEventStoreConfig)
-    globalStore' = runGloballyOrderedEventStoreUsing (flip runSqlPool pool) globalStore
+    globalStore = serializedGlobalStreamEventStore jsonStringSerializer (sqlGlobalStreamEventStore defaultSqlEventStoreConfig)
+    globalStore' = runGlobalStreamEventStoreUsing (flip runSqlPool pool) globalStore
   action store globalStore'

--- a/eventful-test-helpers/src/Eventful/TestHelpers.hs
+++ b/eventful-test-helpers/src/Eventful/TestHelpers.hs
@@ -334,15 +334,15 @@ globalStreamProjectionCacheSpec (GlobalStreamProjectionCacheRunner withStoreAndC
     it "should load from a global stream of events" $ do
       snapshot <- withStoreAndCache $ \store globalStore cache -> do
         _ <- storeEvents store AnyVersion nil [Added 1, Added 2]
-        getLatestGlobalProjectionWithCache globalStore cache (globalStreamProjection "key" counterGlobalProjection)
+        getLatestGlobalProjectionWithCache globalStore cache (globalStreamProjection counterGlobalProjection) "key"
       streamProjectionOrderKey snapshot `shouldBe` 2
       streamProjectionState snapshot `shouldBe` Counter 3
 
     it "should work with updateGlobalProjectionCache" $ do
       snapshot <- withStoreAndCache $ \store globalStore cache -> do
         _ <- storeEvents store AnyVersion nil [Added 1, Added 2, Added 3]
-        updateGlobalProjectionCache globalStore cache (globalStreamProjection "key" counterGlobalProjection)
-        getLatestGlobalProjectionWithCache globalStore cache (globalStreamProjection "key" counterGlobalProjection)
+        updateGlobalProjectionCache globalStore cache (globalStreamProjection counterGlobalProjection) "key"
+        getLatestGlobalProjectionWithCache globalStore cache (globalStreamProjection counterGlobalProjection) "key"
       streamProjectionOrderKey snapshot `shouldBe` 3
       streamProjectionState snapshot `shouldBe` Counter 6
 
@@ -351,7 +351,7 @@ globalStreamProjectionCacheSpec (GlobalStreamProjectionCacheRunner withStoreAndC
     it "should have the correct cached projection value" $ do
       snapshot <- withStoreAndCache $ \store globalStore cache -> do
         insertExampleEvents store
-        updateGlobalProjectionCache globalStore cache (globalStreamProjection "key" counterGlobalProjection)
-        getLatestGlobalProjectionWithCache globalStore cache (globalStreamProjection "key" counterGlobalProjection)
+        updateGlobalProjectionCache globalStore cache (globalStreamProjection counterGlobalProjection) "key"
+        getLatestGlobalProjectionWithCache globalStore cache (globalStreamProjection counterGlobalProjection) "key"
       streamProjectionOrderKey snapshot `shouldBe` 5
       streamProjectionState snapshot `shouldBe` Counter 15

--- a/eventful-test-helpers/src/Eventful/TestHelpers.hs
+++ b/eventful-test-helpers/src/Eventful/TestHelpers.hs
@@ -56,11 +56,11 @@ counterProjection =
   (Counter 0)
   (\(Counter k) (Added x) -> Counter (k + x))
 
-counterGlobalProjection :: Projection Counter (GlobalStreamEvent CounterEvent)
+counterGlobalProjection :: Projection Counter (VersionedStreamEvent CounterEvent)
 counterGlobalProjection =
   Projection
   (Counter 0)
-  (\(Counter k) (StreamEvent _ _ (StreamEvent _ _ (Added x))) -> Counter (k + x))
+  (\(Counter k) (StreamEvent _ _ (Added x)) -> Counter (k + x))
 
 data CounterCommand
   = Increment

--- a/eventful-test-helpers/src/Eventful/TestHelpers.hs
+++ b/eventful-test-helpers/src/Eventful/TestHelpers.hs
@@ -334,15 +334,15 @@ globalStreamProjectionCacheSpec (GlobalStreamProjectionCacheRunner withStoreAndC
     it "should load from a global stream of events" $ do
       snapshot <- withStoreAndCache $ \store globalStore cache -> do
         _ <- storeEvents store AnyVersion nil [Added 1, Added 2]
-        getLatestGlobalProjectionWithCache globalStore cache (globalStreamProjection counterGlobalProjection) "key"
+        getLatestGlobalProjectionWithCache globalStore cache (globalStreamProjection "key" counterGlobalProjection)
       streamProjectionOrderKey snapshot `shouldBe` 2
       streamProjectionState snapshot `shouldBe` Counter 3
 
     it "should work with updateGlobalProjectionCache" $ do
       snapshot <- withStoreAndCache $ \store globalStore cache -> do
         _ <- storeEvents store AnyVersion nil [Added 1, Added 2, Added 3]
-        updateGlobalProjectionCache globalStore cache (globalStreamProjection counterGlobalProjection) "key"
-        getLatestGlobalProjectionWithCache globalStore cache (globalStreamProjection counterGlobalProjection) "key"
+        updateGlobalProjectionCache globalStore cache (globalStreamProjection "key" counterGlobalProjection)
+        getLatestGlobalProjectionWithCache globalStore cache (globalStreamProjection "key" counterGlobalProjection)
       streamProjectionOrderKey snapshot `shouldBe` 3
       streamProjectionState snapshot `shouldBe` Counter 6
 
@@ -351,7 +351,7 @@ globalStreamProjectionCacheSpec (GlobalStreamProjectionCacheRunner withStoreAndC
     it "should have the correct cached projection value" $ do
       snapshot <- withStoreAndCache $ \store globalStore cache -> do
         insertExampleEvents store
-        updateGlobalProjectionCache globalStore cache (globalStreamProjection counterGlobalProjection) "key"
-        getLatestGlobalProjectionWithCache globalStore cache (globalStreamProjection counterGlobalProjection) "key"
+        updateGlobalProjectionCache globalStore cache (globalStreamProjection "key" counterGlobalProjection)
+        getLatestGlobalProjectionWithCache globalStore cache (globalStreamProjection "key" counterGlobalProjection)
       streamProjectionOrderKey snapshot `shouldBe` 5
       streamProjectionState snapshot `shouldBe` Counter 15

--- a/eventful-test-helpers/src/Eventful/TestHelpers.hs
+++ b/eventful-test-helpers/src/Eventful/TestHelpers.hs
@@ -14,13 +14,13 @@ module Eventful.TestHelpers
   , CounterEvent (..)
   , CounterCommand (..)
   , EventStoreRunner (..)
-  , GloballyOrderedEventStoreRunner (..)
+  , GlobalStreamEventStoreRunner (..)
   , eventStoreSpec
-  , sequencedEventStoreSpec
-  , StreamProjectionCacheRunner (..)
-  , streamProjectionCacheSpec
-  , GloballyOrderedProjectionCacheRunner (..)
-  , globallyOrderedProjectionCacheSpec
+  , globalStreamEventStoreSpec
+  , VersionedProjectionCacheRunner (..)
+  , versionedProjectionCacheSpec
+  , GlobalStreamProjectionCacheRunner (..)
+  , globalStreamProjectionCacheSpec
   , Text
   , module X
   ) where
@@ -56,11 +56,11 @@ counterProjection =
   (Counter 0)
   (\(Counter k) (Added x) -> Counter (k + x))
 
-counterGlobalProjection :: Projection Counter (GloballyOrderedEvent CounterEvent)
+counterGlobalProjection :: Projection Counter (GlobalStreamEvent CounterEvent)
 counterGlobalProjection =
   Projection
   (Counter 0)
-  (\(Counter k) (GloballyOrderedEvent _ _ _ (Added x)) -> Counter (k + x))
+  (\(Counter k) (StreamEvent _ _ (StreamEvent _ _ (Added x))) -> Counter (k + x))
 
 data CounterCommand
   = Increment
@@ -93,8 +93,8 @@ deriveJSON (aesonPrefix camelCase) ''CounterCommand
 
 newtype EventStoreRunner m =
   EventStoreRunner (forall a. (EventStore CounterEvent m -> m a) -> IO a)
-newtype GloballyOrderedEventStoreRunner m =
-  GloballyOrderedEventStoreRunner (forall a. (EventStore CounterEvent m -> GloballyOrderedEventStore CounterEvent m -> m a) -> IO a)
+newtype GlobalStreamEventStoreRunner m =
+  GlobalStreamEventStoreRunner (forall a. (EventStore CounterEvent m -> GlobalStreamEventStore CounterEvent m -> m a) -> IO a)
 
 eventStoreSpec
   :: (Monad m)
@@ -106,11 +106,6 @@ eventStoreSpec (EventStoreRunner withStore) = do
       _ <- insertExampleEvents store
       action store
 
-  context "when the event store is empty" $ do
-
-    it "should return versions of -1 for a UUID" $ do
-      withStore (\store -> getLatestVersion store nil) `shouldReturn` (-1)
-
   context "when a few events are inserted" $ do
     let
       sampleEvents = [Added 1, Added 4, Added (-3), Added 5]
@@ -119,88 +114,80 @@ eventStoreSpec (EventStoreRunner withStore) = do
         action store
 
     it "should return events" $ do
-      events' <- withStore' $ \store -> getEvents store nil allEvents
-      (storedEventEvent <$> events') `shouldBe` sampleEvents
+      events' <- withStore' $ \store -> getEvents store (allEvents nil)
+      (streamEventEvent <$> events') `shouldBe` sampleEvents
 
     it "should return correct event versions" $ do
-      (latestVersion, events) <- withStore' $ \store ->
-        (,) <$>
-          getLatestVersion store nil <*>
-          getEvents store nil allEvents
-      latestVersion `shouldBe` 3
-      (storedEventVersion <$> events) `shouldBe` [0, 1, 2, 3]
+      events <- withStore' $ \store -> getEvents store (allEvents nil)
+      (streamEventOrderKey <$> events) `shouldBe` [0, 1, 2, 3]
 
     it "should return correct events with queries" $ do
       (firstEvents, middleEvents, laterEvents, maxEvents) <- withStore' $ \store ->
         (,,,) <$>
-          getEvents store nil (eventsUntil 1) <*>
-          getEvents store nil (eventsStartingAtUntil 1 2) <*>
-          getEvents store nil (eventsStartingAt 2) <*>
-          getEvents store nil (eventsStartingAtTakeLimit 0 2)
-      (storedEventEvent <$> firstEvents) `shouldBe` take 2 sampleEvents
-      (storedEventEvent <$> middleEvents) `shouldBe` take 2 (drop 1 sampleEvents)
-      (storedEventEvent <$> laterEvents) `shouldBe` drop 2 sampleEvents
-      (storedEventEvent <$> maxEvents) `shouldBe` take 2 sampleEvents
+          getEvents store (eventsUntil nil 1) <*>
+          getEvents store (eventsStartingAtUntil nil 1 2) <*>
+          getEvents store (eventsStartingAt nil 2) <*>
+          getEvents store (eventsStartingAtTakeLimit nil 0 2)
+      (streamEventEvent <$> firstEvents) `shouldBe` take 2 sampleEvents
+      (streamEventEvent <$> middleEvents) `shouldBe` take 2 (drop 1 sampleEvents)
+      (streamEventEvent <$> laterEvents) `shouldBe` drop 2 sampleEvents
+      (streamEventEvent <$> maxEvents) `shouldBe` take 2 sampleEvents
 
     it "should return the latest projection" $ do
       projection <- withStore' $ \store ->
-        getLatestProjection store (streamProjection counterProjection nil)
+        getLatestProjection store (versionedStreamProjection nil counterProjection)
       streamProjectionState projection `shouldBe` Counter 7
-      streamProjectionVersion projection `shouldBe` 3
-      streamProjectionUuid projection `shouldBe` nil
+      streamProjectionOrderKey projection `shouldBe` 3
+      streamProjectionKey projection `shouldBe` nil
 
     it "should return the latest projection with some starting StreamProjection" $ do
       projection <- withStore' $ \store -> do
-        initialEvents <- getEvents store nil (eventsUntil 1)
-        let initialProjection = latestProjection counterProjection (storedEventEvent <$> initialEvents)
-        getLatestProjection store (StreamProjection counterProjection nil 1 initialProjection)
+        initialEvents <- getEvents store (eventsUntil nil 1)
+        let initialProjection = latestProjection counterProjection (streamEventEvent <$> initialEvents)
+        getLatestProjection store (StreamProjection nil 1 counterProjection initialProjection)
       streamProjectionState projection `shouldBe` Counter 7
-      streamProjectionVersion projection `shouldBe` 3
-      streamProjectionUuid projection `shouldBe` nil
+      streamProjectionOrderKey projection `shouldBe` 3
+      streamProjectionKey projection `shouldBe` nil
 
   context "when events from multiple UUIDs are inserted" $ do
 
     it "should have the correct events for each aggregate" $ do
       (events1, events2) <- withStoreExampleEvents $ \store ->
-        (,) <$> getEvents store uuid1 allEvents <*> getEvents store uuid2 allEvents
-      (storedEventEvent <$> events1) `shouldBe` Added <$> [1, 4]
-      (storedEventEvent <$> events2) `shouldBe` Added <$> [2, 3, 5]
-      (storedEventProjectionId <$> events1) `shouldBe` [uuid1, uuid1]
-      (storedEventProjectionId <$> events2) `shouldBe` [uuid2, uuid2, uuid2]
-      (storedEventVersion <$> events1) `shouldBe` [0, 1]
-      (storedEventVersion <$> events2) `shouldBe` [0, 1, 2]
+        (,) <$> getEvents store (allEvents uuid1) <*> getEvents store (allEvents uuid2)
+      (streamEventEvent <$> events1) `shouldBe` Added <$> [1, 4]
+      (streamEventEvent <$> events2) `shouldBe` Added <$> [2, 3, 5]
+      (streamEventKey <$> events1) `shouldBe` [uuid1, uuid1]
+      (streamEventKey <$> events2) `shouldBe` [uuid2, uuid2, uuid2]
+      (streamEventOrderKey <$> events1) `shouldBe` [0, 1]
+      (streamEventOrderKey <$> events2) `shouldBe` [0, 1, 2]
 
     it "should return correct event versions" $ do
-      (latestVersion1, latestVersion2, events1, events2) <- withStoreExampleEvents $ \store ->
-        (,,,) <$>
-          getLatestVersion store uuid1 <*>
-          getLatestVersion store uuid2 <*>
-          getEvents store uuid1 allEvents <*>
-          getEvents store uuid2 allEvents
-      latestVersion1 `shouldBe` 1
-      latestVersion2 `shouldBe` 2
-      storedEventEvent <$> events1 `shouldBe` [Added 1, Added 4]
-      storedEventEvent <$> events2 `shouldBe` [Added 2, Added 3, Added 5]
+      (events1, events2) <- withStoreExampleEvents $ \store ->
+        (,) <$>
+          getEvents store (allEvents uuid1) <*>
+          getEvents store (allEvents uuid2)
+      streamEventEvent <$> events1 `shouldBe` [Added 1, Added 4]
+      streamEventEvent <$> events2 `shouldBe` [Added 2, Added 3, Added 5]
 
     it "should return correct events with queries" $ do
       (firstEvents, middleEvents, laterEvents, maxEvents) <- withStoreExampleEvents $ \store ->
         (,,,) <$>
-          getEvents store uuid1 (eventsUntil 1) <*>
-          getEvents store uuid2 (eventsStartingAtUntil 1 2) <*>
-          getEvents store uuid2 (eventsStartingAt 2) <*>
-          getEvents store uuid1 (eventsStartingAtTakeLimit 1 1)
-      (storedEventEvent <$> firstEvents) `shouldBe` [Added 1, Added 4]
-      (storedEventEvent <$> middleEvents) `shouldBe` [Added 3, Added 5]
-      (storedEventEvent <$> laterEvents) `shouldBe` [Added 5]
-      (storedEventEvent <$> maxEvents) `shouldBe` [Added 4]
+          getEvents store (eventsUntil uuid1 1) <*>
+          getEvents store (eventsStartingAtUntil uuid2 1 2) <*>
+          getEvents store (eventsStartingAt uuid2 2) <*>
+          getEvents store (eventsStartingAtTakeLimit uuid1 1 1)
+      (streamEventEvent <$> firstEvents) `shouldBe` [Added 1, Added 4]
+      (streamEventEvent <$> middleEvents) `shouldBe` [Added 3, Added 5]
+      (streamEventEvent <$> laterEvents) `shouldBe` [Added 5]
+      (streamEventEvent <$> maxEvents) `shouldBe` [Added 4]
 
     it "should produce the correct projections" $ do
       (proj1, proj2) <- withStoreExampleEvents $ \store ->
         (,) <$>
-          getLatestProjection store (streamProjection counterProjection uuid1) <*>
-          getLatestProjection store (streamProjection counterProjection uuid2)
-      (streamProjectionState proj1, streamProjectionVersion proj1) `shouldBe` (Counter 5, 1)
-      (streamProjectionState proj2, streamProjectionVersion proj2) `shouldBe` (Counter 10, 2)
+          getLatestProjection store (versionedStreamProjection uuid1 counterProjection) <*>
+          getLatestProjection store (versionedStreamProjection uuid2 counterProjection)
+      (streamProjectionState proj1, streamProjectionOrderKey proj1) `shouldBe` (Counter 5, 1)
+      (streamProjectionState proj2, streamProjectionOrderKey proj2) `shouldBe` (Counter 10, 2)
 
   describe "can handle event storage errors" $ do
 
@@ -235,15 +222,15 @@ eventStoreSpec (EventStoreRunner withStore) = do
           ]
       errors `shouldBe` [Nothing, Nothing, Nothing, Nothing]
 
-sequencedEventStoreSpec
+globalStreamEventStoreSpec
   :: (Monad m)
-  => GloballyOrderedEventStoreRunner m
+  => GlobalStreamEventStoreRunner m
   -> Spec
-sequencedEventStoreSpec (GloballyOrderedEventStoreRunner withStore) = do
+globalStreamEventStoreSpec (GlobalStreamEventStoreRunner withStore) = do
   context "when the event store is empty" $ do
 
     it "shouldn't have any events" $ do
-      events <- withStore (\_ globalStore -> getSequencedEvents globalStore allEvents)
+      events <- withStore (\_ globalStore -> getGlobalEvents globalStore (allEvents ()))
       length events `shouldBe` 0
 
   context "when events from multiple UUIDs are inserted" $ do
@@ -251,25 +238,25 @@ sequencedEventStoreSpec (GloballyOrderedEventStoreRunner withStore) = do
     it "should have the correct events in global order" $ do
       events <- withStore $ \store globalStore -> do
         insertExampleEvents store
-        getSequencedEvents globalStore allEvents
-      (globallyOrderedEventEvent <$> events) `shouldBe` Added <$> [1..5]
-      (globallyOrderedEventProjectionId <$> events) `shouldBe` [uuid1, uuid2, uuid2, uuid1, uuid2]
-      (globallyOrderedEventVersion <$> events) `shouldBe` [0, 0, 1, 1, 2]
-      (globallyOrderedEventSequenceNumber <$> events) `shouldBe` [1..5]
+        getGlobalEvents globalStore (allEvents ())
+      (streamEventEvent . streamEventEvent <$> events) `shouldBe` Added <$> [1..5]
+      (streamEventKey . streamEventEvent <$> events) `shouldBe` [uuid1, uuid2, uuid2, uuid1, uuid2]
+      (streamEventOrderKey . streamEventEvent <$> events) `shouldBe` [0, 0, 1, 1, 2]
+      (streamEventOrderKey <$> events) `shouldBe` [1..5]
 
     it "should handle queries" $ do
       (firstEvents, middleEvents, laterEvents, maxEvents) <- withStore $ \store globalStore -> do
         insertExampleEvents store
         (,,,) <$>
-          getSequencedEvents globalStore (eventsUntil 2) <*>
-          getSequencedEvents globalStore (eventsStartingAtUntil 2 3) <*>
-          getSequencedEvents globalStore (eventsStartingAt 3) <*>
-          getSequencedEvents globalStore (eventsStartingAtTakeLimit 2 3)
+          getGlobalEvents globalStore (eventsUntil () 2) <*>
+          getGlobalEvents globalStore (eventsStartingAtUntil () 2 3) <*>
+          getGlobalEvents globalStore (eventsStartingAt () 3) <*>
+          getGlobalEvents globalStore (eventsStartingAtTakeLimit () 2 3)
 
-      (globallyOrderedEventEvent <$> firstEvents) `shouldBe` Added <$> [1..2]
-      (globallyOrderedEventEvent <$> middleEvents) `shouldBe` Added <$> [2..3]
-      (globallyOrderedEventEvent <$> laterEvents) `shouldBe` Added <$> [3..5]
-      (globallyOrderedEventEvent <$> maxEvents) `shouldBe` Added <$> [2..4]
+      (streamEventEvent . streamEventEvent <$> firstEvents) `shouldBe` Added <$> [1..2]
+      (streamEventEvent . streamEventEvent <$> middleEvents) `shouldBe` Added <$> [2..3]
+      (streamEventEvent . streamEventEvent <$> laterEvents) `shouldBe` Added <$> [3..5]
+      (streamEventEvent . streamEventEvent <$> maxEvents) `shouldBe` Added <$> [2..4]
 
 insertExampleEvents
   :: (Monad m)
@@ -287,14 +274,14 @@ uuid1 = uuidFromInteger 1
 uuid2 :: UUID
 uuid2 = uuidFromInteger 2
 
-newtype StreamProjectionCacheRunner m =
-  StreamProjectionCacheRunner (forall a. (EventStore CounterEvent m -> StreamProjectionCache Counter m -> m a) -> IO a)
+newtype VersionedProjectionCacheRunner m =
+  VersionedProjectionCacheRunner (forall a. (EventStore CounterEvent m -> VersionedProjectionCache Counter m -> m a) -> IO a)
 
-streamProjectionCacheSpec
+versionedProjectionCacheSpec
   :: (Monad m)
-  => StreamProjectionCacheRunner m
+  => VersionedProjectionCacheRunner m
   -> Spec
-streamProjectionCacheSpec (StreamProjectionCacheRunner withStoreAndCache) = do
+versionedProjectionCacheSpec (VersionedProjectionCacheRunner withStoreAndCache) = do
   context "when the store is empty" $ do
 
     it "should be able to store and load simple projections" $ do
@@ -308,32 +295,32 @@ streamProjectionCacheSpec (StreamProjectionCacheRunner withStoreAndCache) = do
     it "should load from a stream of events" $ do
       snapshot <- withStoreAndCache $ \store cache -> do
         _ <- storeEvents store AnyVersion nil [Added 1, Added 2]
-        getLatestProjectionWithCache store cache (streamProjection counterProjection nil)
-      streamProjectionVersion snapshot `shouldBe` 1
+        getLatestProjectionWithCache store cache (versionedStreamProjection nil counterProjection)
+      streamProjectionOrderKey snapshot `shouldBe` 1
       streamProjectionState snapshot `shouldBe` Counter 3
 
     it "should work with updateProjectionCache" $ do
       snapshot <- withStoreAndCache $ \store cache -> do
         _ <- storeEvents store AnyVersion nil [Added 1, Added 2, Added 3]
-        updateProjectionCache store cache (streamProjection counterProjection nil)
-        getLatestProjectionWithCache store cache (streamProjection counterProjection nil)
-      streamProjectionUuid snapshot `shouldBe` nil
-      streamProjectionVersion snapshot `shouldBe` 2
+        updateProjectionCache store cache (versionedStreamProjection nil counterProjection)
+        getLatestProjectionWithCache store cache (versionedStreamProjection nil counterProjection)
+      streamProjectionKey snapshot `shouldBe` nil
+      streamProjectionOrderKey snapshot `shouldBe` 2
       streamProjectionState snapshot `shouldBe` Counter 6
 
-newtype GloballyOrderedProjectionCacheRunner m =
-  GloballyOrderedProjectionCacheRunner
+newtype GlobalStreamProjectionCacheRunner m =
+  GlobalStreamProjectionCacheRunner
   (forall a.
     ( EventStore CounterEvent m
-    -> GloballyOrderedEventStore CounterEvent m
-    -> GloballyOrderedProjectionCache Text Counter m -> m a
+    -> GlobalStreamEventStore CounterEvent m
+    -> GlobalStreamProjectionCache Text Counter m -> m a
     ) -> IO a)
 
-globallyOrderedProjectionCacheSpec
+globalStreamProjectionCacheSpec
   :: (Monad m)
-  => GloballyOrderedProjectionCacheRunner m
+  => GlobalStreamProjectionCacheRunner m
   -> Spec
-globallyOrderedProjectionCacheSpec (GloballyOrderedProjectionCacheRunner withStoreAndCache) = do
+globalStreamProjectionCacheSpec (GlobalStreamProjectionCacheRunner withStoreAndCache) = do
   context "when the store is empty" $ do
 
     it "should be able to store and load simple projections" $ do
@@ -347,24 +334,24 @@ globallyOrderedProjectionCacheSpec (GloballyOrderedProjectionCacheRunner withSto
     it "should load from a global stream of events" $ do
       snapshot <- withStoreAndCache $ \store globalStore cache -> do
         _ <- storeEvents store AnyVersion nil [Added 1, Added 2]
-        getLatestGlobalProjectionWithCache globalStore cache (globallyOrderedProjection counterGlobalProjection) "key"
-      globallyOrderedProjectionSequenceNumber snapshot `shouldBe` 2
-      globallyOrderedProjectionState snapshot `shouldBe` Counter 3
+        getLatestGlobalProjectionWithCache globalStore cache (globalStreamProjection counterGlobalProjection) "key"
+      streamProjectionOrderKey snapshot `shouldBe` 2
+      streamProjectionState snapshot `shouldBe` Counter 3
 
     it "should work with updateGlobalProjectionCache" $ do
       snapshot <- withStoreAndCache $ \store globalStore cache -> do
         _ <- storeEvents store AnyVersion nil [Added 1, Added 2, Added 3]
-        updateGlobalProjectionCache globalStore cache (globallyOrderedProjection counterGlobalProjection) "key"
-        getLatestGlobalProjectionWithCache globalStore cache (globallyOrderedProjection counterGlobalProjection) "key"
-      globallyOrderedProjectionSequenceNumber snapshot `shouldBe` 3
-      globallyOrderedProjectionState snapshot `shouldBe` Counter 6
+        updateGlobalProjectionCache globalStore cache (globalStreamProjection counterGlobalProjection) "key"
+        getLatestGlobalProjectionWithCache globalStore cache (globalStreamProjection counterGlobalProjection) "key"
+      streamProjectionOrderKey snapshot `shouldBe` 3
+      streamProjectionState snapshot `shouldBe` Counter 6
 
   context "when events from multiple UUIDs are inserted" $ do
 
     it "should have the correct cached projection value" $ do
       snapshot <- withStoreAndCache $ \store globalStore cache -> do
         insertExampleEvents store
-        updateGlobalProjectionCache globalStore cache (globallyOrderedProjection counterGlobalProjection) "key"
-        getLatestGlobalProjectionWithCache globalStore cache (globallyOrderedProjection counterGlobalProjection) "key"
-      globallyOrderedProjectionSequenceNumber snapshot `shouldBe` 5
-      globallyOrderedProjectionState snapshot `shouldBe` Counter 15
+        updateGlobalProjectionCache globalStore cache (globalStreamProjection counterGlobalProjection) "key"
+        getLatestGlobalProjectionWithCache globalStore cache (globalStreamProjection counterGlobalProjection) "key"
+      streamProjectionOrderKey snapshot `shouldBe` 5
+      streamProjectionState snapshot `shouldBe` Counter 15

--- a/examples/bank/src/Bank/CLI/RunCommand.hs
+++ b/examples/bank/src/Bank/CLI/RunCommand.hs
@@ -24,7 +24,7 @@ runCLICommand pool (ViewAccountCLI uuid) = do
     getLatestProjection cliEventStore (streamProjection accountBankProjection uuid)
   printJSONPretty (streamProjectionState latestStreamProjection)
 runCLICommand pool (ViewCustomerAccountsCLI name) = do
-  events <- runDB pool $ getSequencedEvents cliGloballyOrderedEventStore allEvents
+  events <- runDB pool $ getGlobalEvents cliGloballyOrderedEventStore allEvents
   let
     projectionEvents = globallyOrderedEventToProjectionEvent <$> events
     allCustomerAccounts = latestProjection customerAccountsProjection projectionEvents

--- a/examples/bank/src/Bank/CLI/RunCommand.hs
+++ b/examples/bank/src/Bank/CLI/RunCommand.hs
@@ -21,13 +21,12 @@ runCLICommand pool (CreateCustomerCLI createCommand) = do
   void $ runDB pool $ commandStoredAggregate cliEventStore customerBankAggregate uuid command
 runCLICommand pool (ViewAccountCLI uuid) = do
   latestStreamProjection <- runDB pool $
-    getLatestProjection cliEventStore (streamProjection accountBankProjection uuid)
+    getLatestProjection cliEventStore (versionedStreamProjection uuid accountBankProjection)
   printJSONPretty (streamProjectionState latestStreamProjection)
 runCLICommand pool (ViewCustomerAccountsCLI name) = do
-  events <- runDB pool $ getGlobalEvents cliGloballyOrderedEventStore allEvents
+  events <- runDB pool $ getGlobalEvents cliGlobalStreamEventStore (allEvents ())
   let
-    projectionEvents = globallyOrderedEventToProjectionEvent <$> events
-    allCustomerAccounts = latestProjection customerAccountsProjection projectionEvents
+    allCustomerAccounts = latestProjection customerAccountsProjection (streamEventEvent <$> events)
     thisCustomerAccounts = getCustomerAccountsFromName allCustomerAccounts name
   case thisCustomerAccounts of
     [] -> putStrLn "No accounts found"

--- a/examples/bank/src/Bank/CLI/Store.hs
+++ b/examples/bank/src/Bank/CLI/Store.hs
@@ -11,7 +11,6 @@ import Control.Monad.IO.Class (MonadIO (..))
 import Data.Aeson
 import Data.Aeson.Encode.Pretty
 import qualified Data.ByteString.Lazy.Char8 as BSL
-import Data.Functor.Contravariant (contramap)
 import Database.Persist.Sqlite
 
 import Eventful
@@ -46,7 +45,7 @@ eventPrinter _ uuid event = liftIO $ printJSONPretty (uuid, event)
 transferManagerHandler :: (MonadIO m) => BankEventHandler m
 transferManagerHandler store _ _ = do
   let
-    projection = contramap streamEventEvent $ processManagerProjection transferProcessManager
+    projection = processManagerProjection transferProcessManager
     globalProjection = globalStreamProjection () projection
   StreamProjection{..} <- getLatestGlobalProjection cliGlobalStreamEventStore globalProjection
   applyProcessManagerCommandsAndEvents transferProcessManager store streamProjectionState

--- a/examples/bank/src/Bank/CLI/Store.hs
+++ b/examples/bank/src/Bank/CLI/Store.hs
@@ -3,7 +3,7 @@
 module Bank.CLI.Store
   ( runDB
   , cliEventStore
-  , cliGloballyOrderedEventStore
+  , cliGlobalStreamEventStore
   , printJSONPretty
   ) where
 
@@ -33,10 +33,10 @@ cliEventStore = synchronousEventBusWrapper store handlers
       , transferManagerHandler
       ]
 
-cliGloballyOrderedEventStore :: (MonadIO m) => GloballyOrderedEventStore BankEvent (SqlPersistT m)
-cliGloballyOrderedEventStore =
-  serializedGloballyOrderedEventStore jsonStringSerializer
-    (sqlGloballyOrderedEventStore defaultSqlEventStoreConfig)
+cliGlobalStreamEventStore :: (MonadIO m) => GlobalStreamEventStore BankEvent (SqlPersistT m)
+cliGlobalStreamEventStore =
+  serializedGlobalStreamEventStore jsonStringSerializer
+    (sqlGlobalStreamEventStore defaultSqlEventStoreConfig)
 
 type BankEventHandler m = EventStore BankEvent (SqlPersistT m) -> UUID -> BankEvent -> SqlPersistT m ()
 
@@ -46,10 +46,10 @@ eventPrinter _ uuid event = liftIO $ printJSONPretty (uuid, event)
 transferManagerHandler :: (MonadIO m) => BankEventHandler m
 transferManagerHandler store _ _ = do
   let
-    projection = contramap globallyOrderedEventToProjectionEvent $ processManagerProjection transferProcessManager
-    globalProjection = globallyOrderedProjection projection
-  GloballyOrderedProjection{..} <- getLatestGlobalProjection cliGloballyOrderedEventStore globalProjection
-  applyProcessManagerCommandsAndEvents transferProcessManager store globallyOrderedProjectionState
+    projection = contramap streamEventEvent $ processManagerProjection transferProcessManager
+    globalProjection = globalStreamProjection projection
+  StreamProjection{..} <- getLatestGlobalProjection cliGlobalStreamEventStore globalProjection
+  applyProcessManagerCommandsAndEvents transferProcessManager store streamProjectionState
 
 printJSONPretty :: (ToJSON a) => a -> IO ()
 printJSONPretty = BSL.putStrLn . encodePretty' (defConfig { confIndent = Spaces 2 })

--- a/examples/bank/src/Bank/CLI/Store.hs
+++ b/examples/bank/src/Bank/CLI/Store.hs
@@ -47,7 +47,7 @@ transferManagerHandler :: (MonadIO m) => BankEventHandler m
 transferManagerHandler store _ _ = do
   let
     projection = contramap streamEventEvent $ processManagerProjection transferProcessManager
-    globalProjection = globalStreamProjection projection
+    globalProjection = globalStreamProjection () projection
   StreamProjection{..} <- getLatestGlobalProjection cliGlobalStreamEventStore globalProjection
   applyProcessManagerCommandsAndEvents transferProcessManager store streamProjectionState
 

--- a/examples/bank/src/Bank/CLI/Store.hs
+++ b/examples/bank/src/Bank/CLI/Store.hs
@@ -46,7 +46,7 @@ transferManagerHandler :: (MonadIO m) => BankEventHandler m
 transferManagerHandler store _ _ = do
   let
     projection = processManagerProjection transferProcessManager
-    globalProjection = globalStreamProjection () projection
+    globalProjection = globalStreamProjection projection
   StreamProjection{..} <- getLatestGlobalProjection cliGlobalStreamEventStore globalProjection
   applyProcessManagerCommandsAndEvents transferProcessManager store streamProjectionState
 

--- a/examples/counter-cli/counter-cli.hs
+++ b/examples/counter-cli/counter-cli.hs
@@ -24,7 +24,7 @@ readAndHandleCommand store = do
   let uuid = nil
 
   -- Get current state and print it out
-  latestStreamProjection <- atomically $ getLatestProjection store (streamProjection counterProjection uuid)
+  latestStreamProjection <- atomically $ getLatestProjection store (versionedStreamProjection uuid counterProjection)
   let
     currentState = streamProjectionState latestStreamProjection
   putStrLn $ "Current state: " ++ show currentState


### PR DESCRIPTION
There is a lot of opportunity to try and deduplicate the logic between querying an individual event stream and querying global state. This PR is an experiment with that. The hope is that we can provide even more query types in the future under this interface. For example, it would be cool to filter by events of a given type, which is possible in stores like postgres where we can add indexes on the JSON.

It's very possible I decide these changes aren't worth the increased complexity and I close this PR :smile: 